### PR TITLE
Detection-cube build guide + edge-length analysis, configurable array size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,15 @@ if(DEFINED HET68_CORE1_SETTLE_MS)
     message(STATUS "het68: core1 settle ms override=${HET68_CORE1_SETTLE_MS}")
 endif()
 
+# Acoustic array cube edge length in millimetres. Any integer edge is supported
+# (e.g. 50/100/128/150/200/256/512); DOA_MAXLAG and the comparison window
+# auto-derive from it in doa.c. Default (unset) is 512 mm.
+#   HET68_DOA_EDGE_MM=150 ./build.sh
+if(DEFINED HET68_DOA_EDGE_MM)
+    add_compile_definitions(HET68_DOA_EDGE_MM=${HET68_DOA_EDGE_MM})
+    message(STATUS "het68: DOA cube edge=${HET68_DOA_EDGE_MM} mm")
+endif()
+
 # Wrap panic at link time as belt-and-suspenders: some pico-sdk libraries may
 # have been pre-built without PICO_PANIC_FUNCTION, so --wrap catches those too.
 target_link_options(pico_6mic_soundcard PRIVATE -Wl,--wrap=panic)

--- a/README.md
+++ b/README.md
@@ -174,10 +174,11 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
 * **Array geometry.** A cube standing on a vertex, **512 mm** edge. Mics 1–3 are
   the three upper faces (mic 1 = north, then +120°, +240° azimuth, all at +35.26°
   elevation); mics 4–6 are the opposite lower faces (−35.26° elevation, azimuths
-  interleaved by 60°). Set `DOA_EDGE_MM` in `doa.c` to change the size (`DOA_MAXLAG`
-  derives from it automatically). How to physically build the cube, what to build it
-  from, and a full 128 / 256 / 512 / 1024 mm edge-length trade-off analysis
-  (accuracy, speed, compute) are in [`array_cube_design.md`](array_cube_design.md).
+  interleaved by 60°). Select the edge at build time with any integer size —
+  `HET68_DOA_EDGE_MM=150 ./build.sh` (default 512 mm); `DOA_MAXLAG` and the
+  comparison window derive from it automatically. How to physically build the cube,
+  what to build it from, and a full edge-length trade-off analysis (accuracy, speed,
+  compute, memory) are in [`array_cube_design.md`](array_cube_design.md).
 
 * **Synchronisation beacon.** The PS1240 piezo emits a periodic BPSK-modulated
   m-sequence burst on a ~4 kHz carrier (its resonance), driven differentially via

--- a/README.md
+++ b/README.md
@@ -174,7 +174,10 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
 * **Array geometry.** A cube standing on a vertex, **512 mm** edge. Mics 1–3 are
   the three upper faces (mic 1 = north, then +120°, +240° azimuth, all at +35.26°
   elevation); mics 4–6 are the opposite lower faces (−35.26° elevation, azimuths
-  interleaved by 60°). Edit `MIC_DIR`/`DOA_EDGE_M` in `doa.c` to change it.
+  interleaved by 60°). Set `DOA_EDGE_MM` in `doa.c` to change the size (`DOA_MAXLAG`
+  derives from it automatically). How to physically build the cube, what to build it
+  from, and a full 128 / 256 / 512 / 1024 mm edge-length trade-off analysis
+  (accuracy, speed, compute) are in [`array_cube_design.md`](array_cube_design.md).
 
 * **Synchronisation beacon.** The PS1240 piezo emits a periodic BPSK-modulated
   m-sequence burst on a ~4 kHz carrier (its resonance), driven differentially via

--- a/README.md
+++ b/README.md
@@ -192,6 +192,26 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
 The Pico SDK is vendored at `./pico-sdk`; no environment variables are required.
 See `BUILDING.md` for details.
 
+### Target board
+
+The default board is `pico2` (Raspberry Pi Pico 2, RP2350A, 4 MB flash, no PSRAM).
+Select a different board with `PICO_BOARD`:
+
+```bash
+./build.sh                                          # default: pico2
+PICO_BOARD=pimoroni_pico_plus2_w_rp2350 ./build.sh  # 16 MB flash, 8 MB PSRAM, Wi-Fi/BT
+```
+
+The **Pimoroni Pico Plus 2 W** (RP2350B) is the recommended upgrade for multi-node
+work: 16 MB flash, 8 MB PSRAM (headroom for recording / on-device detection), and
+2.4 GHz Wi-Fi + Bluetooth for networking nodes. It keeps the Pico footprint and all
+firmware GPIOs fit (RP2350B has 48 GPIO; PSRAM CS is GP47, no conflict). Boards
+whose LED lives on a wireless module do not define `PICO_DEFAULT_LED_PIN`, so the
+heartbeat LED is skipped there (the UART heartbeat still runs). Rationale, PSRAM
+sizing, power (all these boards are 3.3 V designs; USB needs 3.3 V `USB_OTP_VDD`, so
+a fully-1.8 V node is custom-hardware only), and alternatives are in
+[`array_cube_design.md`](array_cube_design.md).
+
 ### TinyUSB / pico-sdk patches
 
 Upstream **Pico SDK 2.2.0** (commit `a1438dff`) ships **TinyUSB 0.18.0**, which

--- a/array_cube_design.md
+++ b/array_cube_design.md
@@ -177,7 +177,38 @@ The correlation core sums over `DOA_N - 2·DOA_MAXLAG` samples. With the current
   and the wavefront must traverse the whole array *within* one window — a plain
   physical consequence of a bigger aperture.
 
-### 5.5 Compute load
+### 5.5 Memory footprint
+
+Bigger cube ⇒ longer maximum delay to search ⇒ **larger comparison window**. In
+`doa.c` the window `DOA_N` auto-scales in power-of-two tiers so the usable span
+stays ≥ the lag search. Only two DOA buffers depend on the edge:
+
+- `g_work[6][DOA_N]` (float) = **24 × DOA_N bytes** — the comparison window; the
+  dominant size-dependent buffer.
+- `s_corr[2·DOA_MAXLAG+1]` (float) — the correlation scratch; a few hundred bytes.
+
+Everything else is fixed: the input ring `g_ring[2048][6]` (int16) = **24576 B**
+regardless of edge, plus `g_energy[6]`.
+
+Per edge (DOA total = ring + `g_work` + `s_corr` + `g_energy`):
+
+- **50 mm** → N=256, `g_work` 6.1 kB, DOA total ~30.1 kB
+- **100 mm** → N=256, `g_work` 6.1 kB, ~30.2 kB
+- **150 mm** → N=256, `g_work` 6.1 kB, ~30.2 kB
+- **200 mm** → N=256, `g_work` 6.1 kB, ~30.3 kB
+- **256 mm** → N=256, ~30.3 kB
+- **512 mm** → N=256, ~30.6 kB
+- **700 mm** → N=512, `g_work` 12.3 kB, ~36.8 kB
+- **1300 mm** → N=1024, `g_work` 24.6 kB, ~49.5 kB
+
+Key point: **memory is stepped, not smooth**. Every edge from ~50 mm up to ~600 mm
+lands in the same N=256 tier, so **50 / 100 / 150 / 200 mm all cost essentially the
+same RAM** (they differ only by the sub-kB `s_corr`). The window doubles only when
+the edge crosses ~600 mm (→512) and ~1200 mm (→1024). Against the RP2350's 520 kB
+SRAM even the 1024-sample tier is negligible. So a bigger cube *does* need a bigger
+window — but the jump is discrete and only matters for the large (>600 mm) builds.
+
+### 5.6 Compute load
 
 MACs per window per pair = `(2·maxlag + 1) · (N − 2·maxlag)`; up to 5 pairs per
 solve, at the ~5 Hz update rate (`DOA_OUT_SAMPLES = 9600`):
@@ -195,7 +226,7 @@ decorrelation** across a long baseline (outdoor coherence between mics drops as 
 baseline grows, which *raises* the delay noise and eats into the theoretical
 resolution gain).
 
-### 5.6 Summary of the trade-off
+### 5.7 Summary of the trade-off
 
 - Bigger edge → **better angular resolution** (linear), but **lower aliasing
   frequency**, **longer window/latency**, **larger & floppier structure**, and
@@ -242,19 +273,25 @@ mechanical rigidity stop limiting you.
 The geometry lives in [`doa.c`](doa.c):
 
 - `DOA_EDGE_MM` — **the one knob**: cube edge in millimetres (integer). Positions
-  scale by `edge/2`; `DOA_MAXLAG` derives from it.
+  scale by `edge/2`; `DOA_MAXLAG` and `DOA_N` derive from it. Default 512 mm.
 - `MIC_DIR[6][3]` — the six face-centre unit directions (unchanged when you only
   scale the cube).
 - `DOA_MAXLAG` — auto-derived as `ceil(edge / 7.15 mm) + 2` samples (the +2 is
   interpolation headroom); no longer a hand-set literal.
-- `DOA_N` — window length; a compile-time guard enforces `DOA_N ≥ 3·DOA_MAXLAG`
-  so the usable correlation window (`DOA_N − 2·DOA_MAXLAG`) stays at least as long
-  as the lag search.
+- `DOA_N` — comparison window; **auto-scales** in power-of-two tiers so the usable
+  span (`DOA_N − 2·DOA_MAXLAG`) stays ≥ the lag search: 256 up to ~600 mm, 512 up
+  to ~1200 mm, 1024 up to ~2400 mm. Above that the build stops with a clear
+  `#error`.
 
-To test a different edge, set only `DOA_EDGE_MM`. If the cube is too large for the
-window the build fails with a clear `#error` telling you to raise `DOA_N` (e.g.
-1024 mm needs `DOA_N ≥ 512`) or shrink the cube. After any change, rebuild with
-`./build.sh` per [`AGENTS.md`](AGENTS.md).
+Any integer edge is supported. Select it at build time without editing source:
+
+```bash
+HET68_DOA_EDGE_MM=150 ./build.sh     # 50 / 100 / 128 / 150 / 200 / 256 / 512 ...
+./build.sh                            # default 512 mm
+```
+
+Rebuild per [`AGENTS.md`](AGENTS.md). The compact sizes (50-200 mm) all share the
+256-sample window, so switching between them changes no buffer size (see §5.5).
 
 ---
 

--- a/array_cube_design.md
+++ b/array_cube_design.md
@@ -241,15 +241,20 @@ mechanical rigidity stop limiting you.
 
 The geometry lives in [`doa.c`](doa.c):
 
-- `DOA_EDGE_M` — cube edge in metres (positions scale by `edge/2`).
+- `DOA_EDGE_MM` — **the one knob**: cube edge in millimetres (integer). Positions
+  scale by `edge/2`; `DOA_MAXLAG` derives from it.
 - `MIC_DIR[6][3]` — the six face-centre unit directions (unchanged when you only
   scale the cube).
-- `DOA_MAXLAG` — must cover `edge / delta_d` samples.
-- `DOA_N` — must keep `DOA_N − 2·DOA_MAXLAG` usable (roughly ≥ half the window).
+- `DOA_MAXLAG` — auto-derived as `ceil(edge / 7.15 mm) + 2` samples (the +2 is
+  interpolation headroom); no longer a hand-set literal.
+- `DOA_N` — window length; a compile-time guard enforces `DOA_N ≥ 3·DOA_MAXLAG`
+  so the usable correlation window (`DOA_N − 2·DOA_MAXLAG`) stays at least as long
+  as the lag search.
 
-To test a different edge, set `DOA_EDGE_M`; `DOA_MAXLAG` and `DOA_N` are derived
-from it and range-checked at compile time (see the `DOA_EDGE_M` block in `doa.c`).
-After any change, rebuild with `./build.sh` per [`AGENTS.md`](AGENTS.md).
+To test a different edge, set only `DOA_EDGE_MM`. If the cube is too large for the
+window the build fails with a clear `#error` telling you to raise `DOA_N` (e.g.
+1024 mm needs `DOA_N ≥ 512`) or shrink the cube. After any change, rebuild with
+`./build.sh` per [`AGENTS.md`](AGENTS.md).
 
 ---
 

--- a/array_cube_design.md
+++ b/array_cube_design.md
@@ -309,3 +309,61 @@ Adds to the electronics BOM in [`wiring_and_bom.md`](wiring_and_bom.md).
 | Pico + Grove shield mounting bracket | 1 | printed; bottom corner or centre |
 | M5 T-nuts + button-head screws | ~40 | 2020 assembly |
 | Cable clips / adhesive mounts | as needed | strain relief + routing along rails |
+
+---
+
+## 9. Node hardware — board options
+
+The default target is `pico2` (RP2350A, 4 MB flash, **no PSRAM**). For a networked
+multi-node build, or to add on-device recording/detection, move to an RP2350B board
+with flash + PSRAM + wireless. Build for it with `PICO_BOARD` (no source change):
+
+```bash
+PICO_BOARD=pimoroni_pico_plus2_w_rp2350 ./build.sh
+```
+
+Recommended and off-the-shelf candidates (all RP2350B, 16 MB flash + 8 MB PSRAM):
+
+- **Pimoroni Pico Plus 2 W** — **recommended.** Only one with **2.4 GHz Wi-Fi +
+  Bluetooth (RM2)**, which is what the multi-node plan needs. Pico footprint,
+  USB-C. SDK board: `pimoroni_pico_plus2_w_rp2350`. (Non-W variant
+  `pimoroni_pico_plus2_rp2350` if wireless is not needed.)
+- **SparkFun Pro Micro RP2350**, **Adafruit Metro RP2350 (w/ PSRAM)**,
+  **Olimex RP2350-PICO2-BB48R** — same memory, no wireless.
+- **Solder Party Stamp XL / Waveshare RP2350-PiZero** — PSRAM footprint unpopulated
+  (you solder your own), so not turnkey.
+
+### PSRAM sizing — 8 MB is enough
+
+The DOA path uses ~31 kB of the 520 kB SRAM (see §5.5), so **8 MB PSRAM is ample**
+for edge detection: ~9.7 s of raw 6-channel/48 k/24-bit look-back, large FFT /
+spectrogram buffers, or a 0.1-2 MB on-device classifier, many times over. The
+bottleneck for detection is compute (M33 @ 150 MHz), not capacity. **A custom 16 MB
+PSRAM board is not worth it** — 128 Mbit QSPI PSRAM is essentially unobtainium
+(would need an RP2354B with 2× 8 MB on both chip-selects, i.e. bespoke hardware).
+Note PSRAM is XIP-cached QSPI and slower than SRAM: use it for capacity (recording,
+models, batch spectral work), keep the realtime correlation loop in SRAM.
+
+### Multi-node gains (why wireless matters)
+
+One node gives **direction only**. Two or more time-synchronised nodes give **3-D
+position + range + tracking** — the big qualitative jump. Localisation accuracy is
+set by the inter-node baseline (tens of metres, ~100× the cube), not the cube size;
+optimal fusion of N nodes also adds up to `10·log10(N)` dB detection SNR (≈+6 dB /
+~1.4-2× range at 4 nodes) plus ~N× coverage. Transport role: **Wi-Fi** carries data
+and coarse sync (PTP / 802.11mc gets to ~µs); **Bluetooth** is fine for
+control/telemetry but too jittery for sample-level TDOA; the on-board **acoustic
+beacon** provides the fine sub-sample sync/ranging. So the transport does not
+improve detection by itself — it enables fusion, and only if it carries adequate
+time sync.
+
+### Power / 1.8 V
+
+All the boards above are **3.3 V designs** (fixed 3.3 V regulator, 3.3 V-populated
+flash/PSRAM, wireless). The RP2350 core is 1.1 V and its `IOVDD`/`QSPI_IOVDD` can
+run at 1.8 V (set the pad `VOLTAGE_SELECT` bit), **but `USB_OTP_VDD` needs a nominal
+3.3 V for the USB full-speed PHY** — so a USB sound-card node cannot run fully on
+1.8 V. A fully-1.8 V node is custom-hardware only, and only viable if it **drops
+USB** (data over Wi-Fi) with 1.8 V flash and a 1.8 V PSRAM part (e.g. APS6404L
+1.8 V variant). The ICS-43434 mics are 1.8 V-capable, but their IO must match the
+board `IOVDD`.

--- a/array_cube_design.md
+++ b/array_cube_design.md
@@ -1,0 +1,269 @@
+# Detection cube — building the 6-microphone array
+
+How to build the physical microphone array for het68, and how the cube edge
+length affects direction-of-arrival (DOA) accuracy, speed and compute load.
+
+This document describes the mechanical build; the acoustic maths matches the
+estimator in [`doa.c`](doa.c). If you change the geometry here, update
+`MIC_DIR` / `DOA_EDGE_M` in `doa.c` to match (see "Firmware coupling" below).
+
+---
+
+## 1. Geometry
+
+The array is a **cube standing on one vertex** (body diagonal vertical), with one
+microphone at the **centre of each of the six faces**, port facing outward along
+the face normal. The six face-centre directions are the six vertices of an
+**octahedron** — three mutually orthogonal baselines passing through the centre.
+
+Per microphone (matching `MIC_DIR` in `doa.c`):
+
+- **Mics 1-3** — upper three faces, elevation **+35.26°**, azimuth 0° / 120° / 240°.
+- **Mics 4-6** — lower three faces, elevation **-35.26°**, azimuth interleaved by 60°
+  (so each lower mic sits opposite an upper one).
+
+Position of each mic from the array centre:
+
+```
+MIC_POS[i] = MIC_DIR[i] * (edge / 2)
+```
+
+so every microphone sits on a sphere of radius `edge/2` (the face-centre radius).
+
+Baselines that the TDOA estimator sees:
+
+- **Opposite faces (max baseline):** `edge`   (e.g. 512 mm)
+- **Adjacent faces:** `edge / √2`             (e.g. 362 mm) — these are orthogonal directions
+- **Face-centre radius:** `edge / 2`          (e.g. 256 mm)
+
+```
+            mic1 (+35.26 deg)
+              \
+   mic3 ------ + ------ mic2      upper ring, 120 deg apart
+              /|
+             / |  <- three orthogonal baselines through centre
+        mic4   mic6
+             \ |
+              \|
+            mic5 (-35.26 deg)     lower ring, opposite the upper faces
+```
+
+Why on-vertex / octahedral: three orthogonal baselines give a well-conditioned
+3-D least-squares solve for azimuth **and** elevation (the `solve3()` step in
+`doa.c`), with no degenerate axis and equal resolution in all directions.
+
+---
+
+## 2. The single number that drives everything
+
+At `Fs = 48 kHz` and `c = 343 m/s`, one sample of inter-mic delay equals
+
+```
+delta_d = c / Fs = 343 / 48000 = 7.15 mm of path difference per sample
+```
+
+Everything below — resolution, lag search size, window length — is this 7.15 mm
+quantum measured against the chosen baseline. `DOA_MAXLAG = 72` in `doa.c` exists
+precisely because the 512 mm max baseline spans `512 / 7.15 = 72` samples.
+
+---
+
+## 3. How to build it — frame
+
+The frame must hold the six mic positions rigidly: **7.15 mm of drift = one whole
+sample of TDOA error**, so aim to keep each mic within roughly ±1 mm of nominal.
+Keep the structure **open / skeletal** — a solid cube body would shadow and reflect
+sound and corrupt the delays. Mount mics on thin standoffs at the geometric
+face-centre points, not on panels.
+
+### Recommended: 2020 aluminium extrusion + 3D-printed corners
+
+- **12× 2020 aluminium extrusion rails** cut to the target edge length.
+- **8× 3D-printed corner cubes** (three-way 2020 joints; PETG or ASA).
+- **6× 3D-printed face-centre mic pods**, each on a light cross-brace or standoff
+  reaching the centre of a face.
+- Pico + Grove shield on a printed bracket at the bottom corner or the centre.
+
+Why this is the right choice for het68: it is **rigid and dimensionally stable**,
+and you can **swap only the rail length** (128 / 256 / 384 / 512 / 768 / 1024 mm)
+to test every edge length in Section 5 with the *same* microphones, cabling and
+firmware. That makes the edge-length comparison a controlled experiment rather
+than a rebuild.
+
+### Alternatives
+
+- **3D-printed skeletal frame (one piece or edge struts).** Cheapest, fastest.
+  Use **PETG or ASA** for outdoor UV/temperature stability — **not PLA** (it
+  creeps and softens in sun, moving the mics). Good up to ~256-384 mm before
+  print-bed size and flex become a problem.
+- **Carbon-fibre tube + printed corner joints.** Light and very stiff; the best
+  option for the large **512-1024 mm** builds where aluminium gets heavy.
+- **Laser-cut panels forming closed faces.** Avoid — solid faces cause diffraction
+  and shadowing. Only acceptable if perforated/open and the mic sits proud of the
+  surface.
+
+---
+
+## 4. How to build it — microphone pods, acoustics and cabling
+
+- **Port outward** along the face normal; nothing in front of the MEMS port.
+- **Wind protection:** open-cell foam windscreen over each pod. Outdoors this is
+  mandatory — wind noise dominates low frequencies and decorrelates the array.
+- **Vibration isolation:** seat each ICS-43434 breakout in a **soft rubber grommet**
+  so frame/motor vibration is not conducted into the mic body.
+- **Strain relief:** anchor each Grove cable at the pod so tension never pulls the
+  mic off its nominal point.
+- **Cabling:** route the six data cables and the shared WS/SCK clock bus
+  (see [`wiring_and_bom.md`](wiring_and_bom.md)) along the rails to the Pico. Keep
+  the two clock daisy-chain branches (mics 1-3, mics 4-6) roughly equal length.
+- **Temperature:** the speed of sound drifts ~**0.6 m/s per °C** (~0.17 %/°C). This
+  is a global *scale* error on all delays, not a geometry error; compensate `c` in
+  firmware from the BME280 that is already on the sensor roadmap in
+  [`wiring_and_bom.md`](wiring_and_bom.md).
+
+---
+
+## 5. Edge length: 128 vs 256 vs 512 vs 1024 mm
+
+All figures use `delta_d = 7.15 mm/sample`, the octahedral geometry above, and the
+existing time-domain GCC estimator in `doa.c`. "Baseline" for resolution/aliasing
+is the max (opposite-face) baseline = `edge`.
+
+### 5.1 Lag search size (max integer lag = edge / 7.15 mm)
+
+- **128 mm** → 18 samples
+- **256 mm** → 36 samples
+- **512 mm** → 72 samples  (current `DOA_MAXLAG`)
+- **1024 mm** → 143 samples
+
+### 5.2 Angular resolution (raw, at broadside ≈ delta_d / edge)
+
+- **128 mm** → **3.20°**
+- **256 mm** → **1.60°**
+- **512 mm** → **0.80°**
+- **1024 mm** → **0.40°**
+
+Resolution **halves (improves) every time the edge doubles** — it is linear in the
+baseline. The parabolic sub-sample interpolation already in `xcorr_delay()`
+improves the effective delay quantum by roughly ×5-10 when SNR is good, so the
+practical figures are several times finer than the raw values — but that gain is
+limited by noise/coherence, not geometry, so the *relative* ranking is unchanged.
+
+### 5.3 Spatial aliasing / grating frequency ≈ c / (2·edge)
+
+- **128 mm** → 1340 Hz
+- **256 mm** → 670 Hz
+- **512 mm** → 335 Hz
+- **1024 mm** → 167 Hz
+
+This is a **soft** limit for broadband time-domain GCC: a wideband source (a drone
+has energy across a broad band and many harmonics) still produces one dominant
+correlation peak, because grating lobes land at different angles for different
+frequencies and only the true delay reinforces across the band. It matters more
+for narrowband tones — a large array leaning on a single tone above this frequency
+can lock onto a grating lobe. Bigger cube ⇒ more reliance on genuine broadband
+content.
+
+### 5.4 Window length and latency (the real constraint of large arrays)
+
+The correlation core sums over `DOA_N - 2·DOA_MAXLAG` samples. With the current
+`DOA_N = 256`:
+
+- **128 mm** (maxlag 18): 220 usable samples — comfortable.
+- **256 mm** (maxlag 36): 184 usable — comfortable.
+- **512 mm** (maxlag 72): 112 usable — fine, current default.
+- **1024 mm** (maxlag 143): `256 - 286 < 0` — **does not fit**. Requires
+  `DOA_N ≥ ~512` (e.g. 226 usable at N=512). A longer window means more latency
+  and the wavefront must traverse the whole array *within* one window — a plain
+  physical consequence of a bigger aperture.
+
+### 5.5 Compute load
+
+MACs per window per pair = `(2·maxlag + 1) · (N − 2·maxlag)`; up to 5 pairs per
+solve, at the ~5 Hz update rate (`DOA_OUT_SAMPLES = 9600`):
+
+- **128 mm** (N=256): ~8.1 k/pair
+- **256 mm** (N=256): ~13.4 k/pair
+- **512 mm** (N=256): ~16.2 k/pair
+- **1024 mm** (N=512): ~64.9 k/pair → ~1.6 MMAC per solve, ~1.6 MMAC/s at 5 Hz
+
+**Conclusion: compute is not the bottleneck.** Even the 1024 mm case is a fraction
+of what the RP2350 M33 FPU delivers at 150 MHz. The genuine costs of a bigger cube
+are, in order: **window length / latency**, **physical size and portability**,
+**frame rigidity** (holding sub-mm over a metre is hard), and **wind/turbulence
+decorrelation** across a long baseline (outdoor coherence between mics drops as the
+baseline grows, which *raises* the delay noise and eats into the theoretical
+resolution gain).
+
+### 5.6 Summary of the trade-off
+
+- Bigger edge → **better angular resolution** (linear), but **lower aliasing
+  frequency**, **longer window/latency**, **larger & floppier structure**, and
+  **worse outdoor coherence**.
+- Smaller edge → **portable, rigid, robust, low latency**, but **coarser
+  resolution**.
+- Range/near-field is **not** a differentiator here: the far-field (Fraunhofer)
+  distance `2·edge²/λ` is only a few metres even at 1024 mm / a few kHz, and drone
+  targets are far beyond that — every size sees a plane wave in practice. A single
+  node gives **direction only**; range needs multi-node triangulation regardless of
+  cube size.
+
+---
+
+## 6. Recommendation and alternative dimensions
+
+- **Default: ~512 mm (current).** Best all-round balance: 0.80° raw / sub-0.1°
+  interpolated resolution, fits the existing `DOA_N = 256` window, low latency,
+  far-field for any real target. Keep it.
+- **Compact / portable variant: 256 mm.** Half the resolution (1.6° raw) but half
+  the size, stiffer, lower latency, easier to hand-carry and weatherproof. Good for
+  a mobile or short-range node.
+- **High-resolution fixed install: 1024 mm.** Only when mounted permanently and
+  rigid, and only after raising `DOA_N` to ≥512. Buys 0.40° raw resolution at the
+  cost of latency, bulk and wind sensitivity.
+- **Avoid 128 mm** except for very compact / higher-frequency-only use: 3.2° raw is
+  marginal and the 1340 Hz aliasing edge starts cutting into useful drone bandwidth
+  from below-ish only if you rely on tones, but the coarse resolution is the real
+  problem.
+
+**Proposed sweet-spot band: ~350-500 mm.** If you want a single fixed size other
+than 512 mm, **~384 mm** is a good compromise (≈1.07° raw resolution, maxlag ≈ 54,
+comfortably inside `DOA_N = 256`, still portable). Practically, though, the
+strongest recommendation is to **build the modular 2020 frame (Section 3) and
+measure**: keep the mics/firmware fixed, swap rail lengths across 256 / 384 / 512 /
+768 mm against a known source, and pick the smallest edge that meets your accuracy
+target — resolution is only worth buying up to the point where wind coherence and
+mechanical rigidity stop limiting you.
+
+---
+
+## 7. Firmware coupling
+
+The geometry lives in [`doa.c`](doa.c):
+
+- `DOA_EDGE_M` — cube edge in metres (positions scale by `edge/2`).
+- `MIC_DIR[6][3]` — the six face-centre unit directions (unchanged when you only
+  scale the cube).
+- `DOA_MAXLAG` — must cover `edge / delta_d` samples.
+- `DOA_N` — must keep `DOA_N − 2·DOA_MAXLAG` usable (roughly ≥ half the window).
+
+To test a different edge, set `DOA_EDGE_M`; `DOA_MAXLAG` and `DOA_N` are derived
+from it and range-checked at compile time (see the `DOA_EDGE_M` block in `doa.c`).
+After any change, rebuild with `./build.sh` per [`AGENTS.md`](AGENTS.md).
+
+---
+
+## 8. Bill of materials — additions for the cube
+
+Adds to the electronics BOM in [`wiring_and_bom.md`](wiring_and_bom.md).
+
+| Item | Qty | Notes |
+|---|---|---|
+| 2020 aluminium extrusion rail | 12 | cut to edge length; buy spare lengths to compare sizes |
+| 3D-printed corner cube (3-way 2020 joint) | 8 | PETG/ASA |
+| 3D-printed face-centre mic pod + standoff | 6 | PETG/ASA; grommet seat for the breakout |
+| Rubber grommet (mic isolation) | 6 | soft, decouples vibration |
+| Open-cell foam windscreen | 6 | mandatory outdoors |
+| Pico + Grove shield mounting bracket | 1 | printed; bottom corner or centre |
+| M5 T-nuts + button-head screws | ~40 | 2020 assembly |
+| Cable clips / adhesive mounts | as needed | strain relief + routing along rails |

--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,9 @@ CMAKE_ARGS=(
 if [ -n "${HET68_CORE1_SETTLE_MS:-}" ]; then
   CMAKE_ARGS+=(-DHET68_CORE1_SETTLE_MS="${HET68_CORE1_SETTLE_MS}")
 fi
+if [ -n "${HET68_DOA_EDGE_MM:-}" ]; then
+  CMAKE_ARGS+=(-DHET68_DOA_EDGE_MM="${HET68_DOA_EDGE_MM}")
+fi
 cmake "${CMAKE_ARGS[@]}"
 
 # build ve verbose režimu (funguje pro Ninja i Make)

--- a/doa.c
+++ b/doa.c
@@ -17,13 +17,19 @@
 // Array geometry — cube standing on a vertex, mics at the six face centres
 // (an octahedron). See README and array_cube_design.md.
 //
-// DOA_EDGE_MM is the ONE knob for the array size: DOA_MAXLAG and the window
-// guard below derive from it, so the same firmware can drive any edge length
-// (128 / 256 / 512 / 1024 mm ...). MIC_DIR stays the same — only the scale
-// changes. Edge is an integer in millimetres so the derivation is a valid
-// integer constant expression usable in the #if guard.
+// DOA_EDGE_MM is the ONE knob for the array size: DOA_MAXLAG and the comparison
+// window below derive from it, so the same firmware can drive any integer edge
+// length (e.g. 50 / 100 / 128 / 150 / 200 / 256 / 512 / 1024 mm). MIC_DIR stays
+// the same — only the scale changes. Edge is an integer in millimetres so the
+// derivation is a valid integer constant expression usable in the #if tiers.
+//
+// Override at build time (default 512 mm):  HET68_DOA_EDGE_MM=150 ./build.sh
 // ---------------------------------------------------------------------------
+#ifdef HET68_DOA_EDGE_MM
+#define DOA_EDGE_MM     HET68_DOA_EDGE_MM
+#else
 #define DOA_EDGE_MM     512
+#endif
 #define DOA_EDGE_M      (DOA_EDGE_MM * 0.001f)
 #define DOA_FACE_R      (DOA_EDGE_M * 0.5f)
 
@@ -45,18 +51,26 @@ static float MIC_POS[6][3];
 #define DOA_FS           ((float)DOA_FS_HZ)
 #define DOA_C_SOUND      (DOA_C_MM_S * 0.001f)
 
-#define DOA_N            256u
-
 // Longest baseline = full edge (opposite faces). One integer sample of TDOA is
 // c/Fs = 343000/48000 = 7.15 mm of path difference, so cover ceil(edge / 7.15)
 // samples plus 2 for the sub-sample parabolic interpolation headroom.
 #define DOA_MAXLAG       ((DOA_EDGE_MM * DOA_FS_HZ + DOA_C_MM_S - 1) / DOA_C_MM_S + 2)
 
-// The GCC core correlates over DOA_N - 2*DOA_MAXLAG samples. Keep the usable
-// window at least as long as the lag search (DOA_N >= 3*DOA_MAXLAG); below that
-// the estimate degrades and can underflow. Raise DOA_N or shrink DOA_EDGE_MM.
-#if (DOA_N) < 3 * (DOA_MAXLAG)
-#error "DOA_N too small for DOA_EDGE_MM: increase DOA_N or reduce the cube edge"
+// Comparison window. The GCC core correlates over DOA_N - 2*DOA_MAXLAG samples,
+// so the window must grow with the cube — a bigger array means a longer maximum
+// delay to search. Auto-pick the smallest power-of-two window that keeps the
+// usable span at least as long as the lag search (DOA_N >= 3*DOA_MAXLAG). This
+// is the only DOA buffer that scales with edge length (g_work = 6*DOA_N floats,
+// i.e. 24*DOA_N bytes); the ring buffer is fixed. Edge crossovers: 256 samples
+// up to ~600 mm, 512 up to ~1200 mm, 1024 up to ~2400 mm.
+#if   DOA_MAXLAG <= 85
+#define DOA_N            256u
+#elif DOA_MAXLAG <= 170
+#define DOA_N            512u
+#elif DOA_MAXLAG <= 341
+#define DOA_N            1024u
+#else
+#error "DOA_EDGE_MM too large: add a larger DOA_N tier in doa.c"
 #endif
 
 #define DOA_OUT_SAMPLES  9600u
@@ -66,6 +80,11 @@ static float MIC_POS[6][3];
 // SPSC ring: core0 producer, core1 consumer.
 #define DOA_RING_SZ     2048u
 #define DOA_RING_MASK   (DOA_RING_SZ - 1u)
+// The consumer reads the most recent DOA_N samples while the producer keeps
+// writing; keep at least 2x headroom so a window is never overwritten mid-read.
+#if DOA_RING_SZ < 2u * DOA_N
+#error "DOA_RING_SZ too small for DOA_N: increase DOA_RING_SZ"
+#endif
 static volatile int16_t  g_ring[DOA_RING_SZ][6];
 static volatile uint32_t g_head;
 

--- a/doa.c
+++ b/doa.c
@@ -14,9 +14,17 @@
 #include <math.h>
 
 // ---------------------------------------------------------------------------
-// Array geometry — 512 mm cube on vertex (see README).
+// Array geometry — cube standing on a vertex, mics at the six face centres
+// (an octahedron). See README and array_cube_design.md.
+//
+// DOA_EDGE_MM is the ONE knob for the array size: DOA_MAXLAG and the window
+// guard below derive from it, so the same firmware can drive any edge length
+// (128 / 256 / 512 / 1024 mm ...). MIC_DIR stays the same — only the scale
+// changes. Edge is an integer in millimetres so the derivation is a valid
+// integer constant expression usable in the #if guard.
 // ---------------------------------------------------------------------------
-#define DOA_EDGE_M      0.512f
+#define DOA_EDGE_MM     512
+#define DOA_EDGE_M      (DOA_EDGE_MM * 0.001f)
 #define DOA_FACE_R      (DOA_EDGE_M * 0.5f)
 
 static const float MIC_DIR[6][3] = {
@@ -30,10 +38,27 @@ static const float MIC_DIR[6][3] = {
 
 static float MIC_POS[6][3];
 
-#define DOA_FS           48000.0f
-#define DOA_C_SOUND      343.0f
+// Sample rate and speed of sound, kept in one place as both integer forms (for
+// the DOA_MAXLAG / #if derivation) and float forms (for the estimator maths).
+#define DOA_FS_HZ        48000
+#define DOA_C_MM_S       343000
+#define DOA_FS           ((float)DOA_FS_HZ)
+#define DOA_C_SOUND      (DOA_C_MM_S * 0.001f)
+
 #define DOA_N            256u
-#define DOA_MAXLAG       72
+
+// Longest baseline = full edge (opposite faces). One integer sample of TDOA is
+// c/Fs = 343000/48000 = 7.15 mm of path difference, so cover ceil(edge / 7.15)
+// samples plus 2 for the sub-sample parabolic interpolation headroom.
+#define DOA_MAXLAG       ((DOA_EDGE_MM * DOA_FS_HZ + DOA_C_MM_S - 1) / DOA_C_MM_S + 2)
+
+// The GCC core correlates over DOA_N - 2*DOA_MAXLAG samples. Keep the usable
+// window at least as long as the lag search (DOA_N >= 3*DOA_MAXLAG); below that
+// the estimate degrades and can underflow. Raise DOA_N or shrink DOA_EDGE_MM.
+#if (DOA_N) < 3 * (DOA_MAXLAG)
+#error "DOA_N too small for DOA_EDGE_MM: increase DOA_N or reduce the cube edge"
+#endif
+
 #define DOA_OUT_SAMPLES  9600u
 #define DOA_RMS_ACTIVE   4.0f
 #define DOA_TDOA_SIGN    (+1.0f)

--- a/main.c
+++ b/main.c
@@ -772,12 +772,18 @@ int main(void)
     dbg_puts("DOA: core1 launched (3D TDOA, 512mm cube on vertex)\n");
 #endif
 
+    // Heartbeat LED. Boards whose LED is on a wireless module (e.g. Pico W /
+    // Pico Plus 2 W) do not define PICO_DEFAULT_LED_PIN; skip the blink there —
+    // the UART heartbeat (dbg_heartbeat) remains the primary liveness signal and
+    // we avoid pulling in the CYW43 driver just to toggle an LED.
+#ifdef PICO_DEFAULT_LED_PIN
     const uint led_pin = PICO_DEFAULT_LED_PIN;
     gpio_init(led_pin);
     gpio_set_dir(led_pin, GPIO_OUT);
 
     bool led_state = false;
     absolute_time_t next_led = make_timeout_time_ms(500);
+#endif
     absolute_time_t next_heartbeat = make_timeout_time_ms(2000);
     uint32_t hb_count = 0;
 
@@ -793,12 +799,14 @@ int main(void)
         // Audio frames are produced in tud_audio_tx_done_pre_load_cb(), driven by
         // the USB IN cadence — nothing to pump from the main loop here.
 
+#ifdef PICO_DEFAULT_LED_PIN
         uint32_t blink_ms = tud_audio_mounted() ? 100u : 500u;
         if (absolute_time_diff_us(get_absolute_time(), next_led) <= 0) {
             led_state = !led_state;
             gpio_put(led_pin, led_state);
             next_led = make_timeout_time_ms(blink_ms);
         }
+#endif
 
         if (absolute_time_diff_us(get_absolute_time(), next_heartbeat) <= 0) {
             hb_count++;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds an engineering design document for the 6-microphone detection cube and makes the array size a build-time-selectable knob in firmware, with an auto-scaling comparison window.

### New: `array_cube_design.md`
- **How and from what to build the cube.** On-vertex cube / octahedral geometry (mics at the six face centres), recommended frame (2020 aluminium extrusion + 3D-printed corners and mic pods) plus alternatives, mic pod acoustics (windscreen, vibration grommet, strain relief), rigidity/temperature notes, and a BOM addition table.
- **Edge-length analysis** for 128 / 256 / 512 / 1024 mm: delay quantum (7.15 mm/sample), lag-search size, angular resolution (3.2 / 1.6 / 0.80 / 0.40 deg raw), spatial aliasing, window length / latency, compute load, and a new **memory-footprint** section. Conclusion: compute is not the bottleneck; memory is stepped (all 50-600 mm share the 256-sample window).
- **Recommendation**: keep ~512 mm default; 256 mm portable; 1024 mm only for fixed installs; ~350-500 mm sweet-spot band; build a modular frame and measure.

### Firmware
- **Build-time array size**: `HET68_DOA_EDGE_MM=<mm> ./build.sh` (default 512). Any integer edge is supported (50 / 100 / 128 / 150 / 200 / 256 / 512 / 1024 ...) — wired through `CMakeLists.txt` and `build.sh`, consumed in [`doa.c`](doa.c). No source edit needed to change size.
- **`DOA_MAXLAG`** auto-derives from the edge (`ceil(edge / 7.15 mm) + 2`).
- **Auto-scaling comparison window**: `DOA_N` now picks the smallest power-of-two tier that keeps the usable span >= the lag search (256 up to ~600 mm, 512 up to ~1200 mm, 1024 up to ~2400 mm), with a clear `#error` above that. A ring-buffer size guard was added too.

### Docs
- README updated with the build-time size option and a pointer to the guide.

## Validation
- **Full `./build.sh` (ARM, pico2) passes** at the default 512 mm: `.elf` + `.uf2` produced, `doa.c` clean.
- **Every requested size builds**: 50 / 100 / 150 / 200 mm (N=256), plus 700 mm (N=512) and 1300 mm (N=1024) tier boundaries; 2500 mm correctly stops with the too-large `#error`.
- Macro/tier logic also cross-checked on the host compiler.
- (Environment note: this VM's default `c++` is clang without libstdc++, which breaks the SDK's host-tool sub-builds; building with `CC=gcc CXX=g++` resolves it. Not a code change.)

## Notes
- No changes to the realtime audio path or the ring-buffer producer.
- Default behaviour preserved (512 mm → 256-sample window as before; `DOA_MAXLAG` 74 vs the old literal 72 = slightly wider, more correct lag search with interpolation headroom).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d052253-c03c-4884-a312-2511ab53691a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d052253-c03c-4884-a312-2511ab53691a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

