### PR TITLE
ci: build firmware on semver GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+# Build firmware on a GitHub Release whose tag is semver core (semver.org):
+#   x.y.z   or   vx.y.z
+# Uploads UF2 + ELF as release assets.
+name: Release firmware
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-firmware-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-upload:
+    name: Build pico2 firmware
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate semver tag (x.y.z or vx.y.z)
+        id: semver
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -Eeuo pipefail
+          # Core SemVer only: MAJOR.MINOR.PATCH, optional leading "v".
+          # See https://semver.org/ — pre-release / build metadata not accepted here.
+          if [[ ! "${TAG}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag '${TAG}' is not x.y.z or vx.y.z (semver.org core)."
+            echo "Create the release with a tag like 1.2.3 or v1.2.3."
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Validated semver tag: ${TAG} (version ${VERSION})"
+
+      - name: Install ARM toolchain and build deps
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            build-essential \
+            g++ \
+            cmake \
+            git \
+            python3 \
+            ninja-build \
+            gcc-arm-none-eabi \
+            libnewlib-arm-none-eabi \
+            libstdc++-arm-none-eabi-newlib
+          arm-none-eabi-gcc --version | head -1
+          cmake --version | head -1
+
+      - name: Fetch Pico SDK (pinned 2.2.0)
+        run: ./scripts/fetch_pico_sdk.sh
+
+      - name: Build firmware
+        env:
+          PICO_BOARD: pico2
+          # Prefer GNU host toolchain for picotool (SDK host tool), not clang-as-c++.
+          CC: gcc
+          CXX: g++
+        run: ./build.sh
+
+      - name: Stage release artifacts
+        env:
+          VERSION: ${{ steps.semver.outputs.version }}
+        run: |
+          set -Eeuo pipefail
+          test -f build/pico_6mic_soundcard.uf2
+          test -f build/pico_6mic_soundcard.elf
+          mkdir -p dist
+          cp -v build/pico_6mic_soundcard.uf2 "dist/het68-${VERSION}-pico2.uf2"
+          cp -v build/pico_6mic_soundcard.elf "dist/het68-${VERSION}-pico2.elf"
+          # Keep plain names too (match local ./build.sh output).
+          cp -v build/pico_6mic_soundcard.uf2 dist/pico_6mic_soundcard.uf2
+          cp -v build/pico_6mic_soundcard.elf dist/pico_6mic_soundcard.elf
+          ls -la dist/
+
+      - name: Upload assets to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.semver.outputs.tag }}
+          files: |
+            dist/het68-${{ steps.semver.outputs.version }}-pico2.uf2
+            dist/het68-${{ steps.semver.outputs.version }}-pico2.elf
+            dist/pico_6mic_soundcard.uf2
+            dist/pico_6mic_soundcard.elf
+          fail_on_unmatched_files: true

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,7 +1,18 @@
 # Build (vendored Pico SDK)
 
-This project uses the vendored Pico SDK located at `./pico-sdk` (relative to
-`CMakeLists.txt`). No environment variables are required.
+This project uses a local Pico SDK clone at `./pico-sdk` (relative to
+`CMakeLists.txt`; the directory is gitignored). No environment variables are
+required after the SDK is present.
+
+## Fetch the Pico SDK (first time / CI)
+
+```bash
+./scripts/fetch_pico_sdk.sh
+```
+
+This checks out **Pico SDK 2.2.0** (TinyUSB 0.18.0) and initializes the
+`lib/tinyusb` submodule. TinyUSB patches are applied automatically by
+`./build.sh` via `patches/apply_all.py`.
 
 ## Recommended
 
@@ -12,6 +23,18 @@ This project uses the vendored Pico SDK located at `./pico-sdk` (relative to
 `build.sh` configures and builds for `PICO_BOARD=pico2` (RP2350) and produces
 `build/pico_6mic_soundcard.uf2` and `.elf`. Pass `HET68_USB_DIAG=ON ./build.sh`
 to build the diagnostic firmware (simulated 1 kHz tone, no I2S).
+
+## GitHub Releases (CI)
+
+Publishing a GitHub Release with a SemVer core tag (`x.y.z` or `vx.y.z`, see
+[semver.org](https://semver.org/)) triggers
+[`.github/workflows/release.yml`](.github/workflows/release.yml): it fetches the
+SDK, builds the default `pico2` firmware, and uploads `.uf2` / `.elf` assets to
+that release.
+
+- Releases page: https://github.com/fedurca/het68/releases
+- Example tags: `1.0.0`, `v1.0.0` (pre-release suffixes like `-rc.1` are not
+  accepted by the release workflow)
 
 ## Manual CMake (Unix Makefiles)
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,26 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   receive/ranging side is a later phase. The beacon count appears in the heartbeat
   (`bcn=`).
 
+## Downloads
+
+Pre-built firmware for each tagged release is published on GitHub Releases:
+
+**https://github.com/fedurca/het68/releases**
+
+Create a GitHub Release whose tag is SemVer core ([semver.org](https://semver.org/))
+— `x.y.z` or `vx.y.z` (e.g. `1.2.3` / `v1.2.3`) — and CI builds the default
+`pico2` firmware and attaches `.uf2` / `.elf` assets to that release.
+
 ## Build
 
-The Pico SDK is vendored at `./pico-sdk`; no environment variables are required.
+The Pico SDK is cloned locally into `./pico-sdk` (gitignored); no environment
+variables are required. On a fresh checkout:
+
+```bash
+./scripts/fetch_pico_sdk.sh   # Pico SDK 2.2.0 + TinyUSB submodule
+./build.sh
+```
+
 See `BUILDING.md` for details.
 
 ### Target board
@@ -270,6 +287,10 @@ HET68_USB_DIAG=ON ./build.sh
 
 ## Flash
 
+Download a pre-built `.uf2` / `.elf` from
+[GitHub Releases](https://github.com/fedurca/het68/releases), or build locally
+(`./scripts/fetch_pico_sdk.sh && ./build.sh`).
+
 * **Via Raspberry Pi Debug Probe (SWD), recommended for the lab setup:**
 
 ```bash
@@ -278,7 +299,8 @@ HET68_USB_DIAG=ON ./build.sh
 ```
 
 * **Via UF2 / BOOTSEL:** hold `BOOTSEL` while plugging in the Pico, then copy
-  `build/pico_6mic_soundcard.uf2` to the `RP2350` mass-storage volume.
+  `build/pico_6mic_soundcard.uf2` (or the versioned asset from the release) to
+  the `RP2350` mass-storage volume.
 
 ## Lab capture
 

--- a/scripts/fetch_pico_sdk.sh
+++ b/scripts/fetch_pico_sdk.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# fetch_pico_sdk.sh — clone/checkout the Pico SDK pin used by this project.
+#
+# Pico SDK is gitignored (local clone / CI fetch), not committed as a submodule.
+# Pin matches README / PATCHES.md: Pico SDK 2.2.0 + TinyUSB 0.18.0.
+#
+# Usage (from repo root or anywhere):
+#   ./scripts/fetch_pico_sdk.sh
+#   PICO_SDK_REF=2.2.0 ./scripts/fetch_pico_sdk.sh   # override pin (advanced)
+
+set -Eeuo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+SDK_DIR="${ROOT}/pico-sdk"
+# Pico SDK 2.2.0 release tag (commit a1438dff…, ships TinyUSB 0.18.0).
+# Keep in sync with README.md / PATCHES.md / UPSTREAM_DELTA.md.
+PICO_SDK_REF="${PICO_SDK_REF:-2.2.0}"
+PICO_SDK_URL="${PICO_SDK_URL:-https://github.com/raspberrypi/pico-sdk.git}"
+
+if [ -d "${SDK_DIR}/.git" ]; then
+  echo "pico-sdk: checking out ${PICO_SDK_REF}"
+  git -C "${SDK_DIR}" fetch --tags --depth 1 origin "refs/tags/${PICO_SDK_REF}:refs/tags/${PICO_SDK_REF}" 2>/dev/null \
+    || git -C "${SDK_DIR}" fetch --depth 1 origin "${PICO_SDK_REF}"
+  git -C "${SDK_DIR}" checkout --force "${PICO_SDK_REF}"
+else
+  echo "pico-sdk: cloning ${PICO_SDK_REF}"
+  rm -rf "${SDK_DIR}"
+  git clone --depth 1 --branch "${PICO_SDK_REF}" "${PICO_SDK_URL}" "${SDK_DIR}"
+fi
+
+echo "pico-sdk: init tinyusb submodule"
+git -C "${SDK_DIR}" submodule update --init --depth 1 lib/tinyusb
+
+echo "pico-sdk: OK @ $(git -C "${SDK_DIR}" rev-parse HEAD) (${PICO_SDK_REF})"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds GitHub Actions CI/CD so publishing a GitHub Release with a SemVer core tag builds and attaches firmware artifacts.

### Trigger
- Event: `release` → `published`
- Accepted tags ([semver.org](https://semver.org/) core only): `x.y.z` or `vx.y.z` (e.g. `1.2.3`, `v1.2.3`)
- Pre-release suffixes (`-rc.1`, etc.) are rejected

### Pipeline
1. Validate tag
2. Install ARM toolchain + host build deps
3. `./scripts/fetch_pico_sdk.sh` (Pico SDK **2.2.0** + TinyUSB)
4. `./build.sh` (`PICO_BOARD=pico2`)
5. Upload to the same release:
   - `het68-<version>-pico2.uf2` / `.elf`
   - `pico_6mic_soundcard.uf2` / `.elf`

### Docs
- README: **Downloads** section → https://github.com/fedurca/het68/releases
- BUILDING.md: CI / Releases notes + SDK fetch steps

### Verified locally
`./scripts/fetch_pico_sdk.sh && CC=gcc CXX=g++ ./build.sh` produced `build/pico_6mic_soundcard.{uf2,elf}`.

### How to use after merge
1. GitHub → Releases → Draft a new release
2. Tag: `v1.0.0` (or `1.0.0`)
3. Publish → workflow builds and attaches UF2/ELF
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

