### PR TITLE
ci: upload only versioned UF2/ELF release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,11 +76,9 @@ jobs:
           test -f build/pico_6mic_soundcard.uf2
           test -f build/pico_6mic_soundcard.elf
           mkdir -p dist
+          # One pair per release — versioned names (same bytes as local build output).
           cp -v build/pico_6mic_soundcard.uf2 "dist/het68-${VERSION}-pico2.uf2"
           cp -v build/pico_6mic_soundcard.elf "dist/het68-${VERSION}-pico2.elf"
-          # Keep plain names too (match local ./build.sh output).
-          cp -v build/pico_6mic_soundcard.uf2 dist/pico_6mic_soundcard.uf2
-          cp -v build/pico_6mic_soundcard.elf dist/pico_6mic_soundcard.elf
           ls -la dist/
 
       - name: Upload assets to GitHub Release
@@ -90,6 +88,4 @@ jobs:
           files: |
             dist/het68-${{ steps.semver.outputs.version }}-pico2.uf2
             dist/het68-${{ steps.semver.outputs.version }}-pico2.elf
-            dist/pico_6mic_soundcard.uf2
-            dist/pico_6mic_soundcard.elf
           fail_on_unmatched_files: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Release assets were uploaded twice (identical SHA256): versioned `het68-<ver>-pico2.*` and plain `pico_6mic_soundcard.*`. Keep only the versioned pair.

Also removed the duplicate assets from the existing `1.0.0` release.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

