### PR TITLE
doa 1.0.5: ACID opportunistic flash, UART gallery I/O, bird detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,35 +157,44 @@ BOM and module layout: `wiring_and_bom.md`.
 
 Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
 
-* **Multi-source DOA (drone + vehicle + single walker) with flash diarization.**
-  core1 runs three parallel front-ends:
+* **Multi-source DOA (drone + vehicle + bird + single walker) with ACID flash diarization.**
+  core1 runs four parallel front-ends:
 
   | Class | Band | Cue | Tracks |
   |---|---|---|---|
   | **drone** | ~800 Hz–6 kHz | continuous, wind gate, crest limit | up to **2** |
   | **vehicle** | ~80 Hz–2.5 kHz | continuous pass-by → **ICE** / **EV** | up to **2** |
+  | **bird** | ~2–8 kHz | chirp bout → songbird / corvid / bird | up to **2** |
   | **walker** | ~150 Hz–600 Hz | footstep onset bout (≥3 steps) → human/cat/dog | **1** |
 
-  Recognised walkers/vehicles are stored in a flash-backed **entity gallery**
-  (last 4 KiB sector, up to 16 signatures — see `entity_store.c`). On boot the
-  gallery is listed on UART (`=== entity store (flash) ===`). Re-ID uses
-  `entity=` + heuristic `match=` 0–1. Walkers also get ground `rng`/`x`/`y`
-  (height: `edge·√3/2` or `HET68_DOA_HEIGHT_MM`). UART example:
+  Recognised entities live in a **RAM-first gallery** persisted with an **ACID
+  dual-slot** scheme in the last two 4 KiB flash sectors (`entity_store.c`, blob
+  v2: magic + seq + CRC32). `match_or_create` never touches flash; `entity_store_poll()`
+  erases/programs **one page at a time only when USB audio alt=0**, so streaming
+  is not stalled. On boot the gallery is listed on UART. Re-ID uses `entity=` +
+  heuristic `match=` 0–1. Birds report DOA `az`/`el` as position; walkers also get
+  ground `rng`/`x`/`y` (height: `edge·√3/2` or `HET68_DOA_HEIGHT_MM`).
+
+  UART gallery transfer: `ENT LIST` | `ENT EXPORT` | `ENT IMPORT` … `ENTHEX …` …
+  `ENT END` | `ENT HELP`. Import validates CRC then marks dirty; flash commit is
+  opportunistic when USB is idle.
+
+  UART example:
 
   ```
   === entity store (flash) n=2 next_id=3 ===
   ENT id=1 class=human hits=4 cadence=1.80Hz low=0.48 mid=0.00 high=0.14 lvl=-40.00dB
-  ENT id=2 class=ice hits=1 cadence=0.50Hz low=0.52 mid=0.28 high=0.20 lvl=-28.00dB
+  ENT id=2 class=songbird hits=1 cadence=4.20Hz low=0.20 mid=0.10 high=0.55 lvl=-36.00dB
   === end entity store ===
   SRC class=drone id=0 az=137.4 el=22.8 conf=0.7 lvl=-31.2dB
-  ENTITY id=2 class=ice frames=5 match=0.00 low=0.52 mid=0.28 high=0.20 daz=40.0deg
+  SRC class=songbird entity=2 az=210.0 el=35.0 conf=0.6 lvl=-36.0dB match=0.71 (bird position)
   SRC class=human entity=1 az=45.0 el=-32.1 conf=0.5 lvl=-40.0dB match=0.82 cadence=1.80Hz rng=1.8m x=1.3 y=1.2
-  TRACKS drone=1 vehicle=1 walker=1 entity=1
+  TRACKS drone=1 vehicle=0 bird=1 walker=1 entity=2
   ```
 
-  - Flash saves use `flash_safe_execute` (may briefly glitch USB audio; rare).
   - Species / ICE·EV / re-ID are best-effort heuristics, not a trained model.
   - Walker tracking assumes **one** walking entity at a time.
+  - Upgrading from gallery blob v1 clears the old single-sector store once.
 
 * **Array geometry.** A cube standing on a vertex, **512 mm** edge. Mics 1–3 are
   the three upper faces (mic 1 = north, then +120°, +240° azimuth, all at +35.26°

--- a/debug_io.c
+++ b/debug_io.c
@@ -95,3 +95,12 @@ void dbg_puthex32(uint32_t v) {
     dbg_puthex8((uint8_t)(v >> 8));
     dbg_puthex8((uint8_t)v);
 }
+
+bool dbg_rx_available(void) {
+    return uart_is_readable(uart_default);
+}
+
+int dbg_getc(void) {
+    if (!uart_is_readable(uart_default)) return -1;
+    return (int)uart_getc(uart_default);
+}

--- a/debug_io.h
+++ b/debug_io.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdint.h>
+#include <stdbool.h>
 
 // UART (GP0/GP1 via PICO_DEFAULT_UART_*_PIN) + optional USB CDC debug output.
 void dbg_init(void);
@@ -9,6 +10,10 @@ void dbg_puts(const char *s);
 void dbg_putu32(uint32_t v);
 void dbg_puthex8(uint8_t v);
 void dbg_puthex32(uint32_t v);
+
+// Non-blocking UART RX helpers (debug probe UART).
+bool dbg_rx_available(void);
+int dbg_getc(void);   // -1 if none
 
 // Coarse, cross-core line lock so debug lines emitted from core0 (heartbeat)
 // and core1 (DOA) never interleave on the shared UART. Wrap one full line:

--- a/doa.c
+++ b/doa.c
@@ -88,12 +88,17 @@ static float MIC_POS[6][3];
 
 #define DOA_MAX_DRONE       2
 #define DOA_MAX_VEHICLE     2
+#define DOA_MAX_BIRD        2
 #define DOA_GATE_DEG        30.0f
 #define DOA_TRACK_TTL       12u
 #define DOA_VEH_MIN_FRAMES  4u       // ~0.8 s continuous before vehicle entity
 #define DOA_VEH_GAP_FRAMES  3u
 #define DOA_VEH_RMS         6.0f
 #define DOA_VEH_CREST_MAX   4.5f     // continuous pass-by, not footfall spikes
+#define DOA_BIRD_RMS        2.0f
+#define DOA_BIRD_MIN_FRAMES 3u
+#define DOA_BIRD_GAP_FRAMES 2u
+#define DOA_BIRD_CREST_MIN  2.8f     // tonal / chirpy
 
 #define DOA_RING_SZ         2048u
 #define DOA_RING_MASK       (DOA_RING_SZ - 1u)
@@ -110,6 +115,7 @@ volatile uint32_t g_doa_iter;
 volatile uint32_t g_doa_ndrone;
 volatile uint32_t g_doa_nwalker;
 volatile uint32_t g_doa_nvehicle;
+volatile uint32_t g_doa_nbird;
 volatile uint32_t g_doa_entity_id;
 
 void doa_ring_push(const int16_t s6[6]) {
@@ -207,6 +213,23 @@ static const biquad_coef_t k_lpf1200 = {
     5.5427172103e-03f, 1.1085434421e-02f, 5.5427172103e-03f,
     -1.7786317778e+00f, 8.0080264667e-01f
 };
+// Bird song / call band ~2–8 kHz (+ 4 kHz split for species cues).
+static const biquad_coef_t k_hpf2000 = {
+    8.3089802127e-01f, -1.6617960425e+00f, 8.3089802127e-01f,
+    -1.6329931619e+00f, 6.9059892324e-01f
+};
+static const biquad_coef_t k_lpf8000 = {
+    1.5505102572e-01f, 3.1010205144e-01f, 1.5505102572e-01f,
+    -6.2020410289e-01f, 2.4040820577e-01f
+};
+static const biquad_coef_t k_hpf4000 = {
+    6.8930616877e-01f, -1.3786123375e+00f, 6.8930616877e-01f,
+    -1.2796324250e+00f, 4.7759225007e-01f
+};
+static const biquad_coef_t k_lpf4000 = {
+    4.9489956269e-02f, 9.8979912537e-02f, 4.9489956269e-02f,
+    -1.2796324250e+00f, 4.7759225007e-01f
+};
 
 static inline float biquad_step(const biquad_coef_t *c, biquad_mem_t *s, float x) {
     float y = c->b0 * x + s->z1;
@@ -224,8 +247,11 @@ typedef enum {
     CLS_HUMAN = ENT_HUMAN,
     CLS_CAT   = ENT_CAT,
     CLS_DOG   = ENT_DOG,
-    CLS_ICE   = ENT_ICE,
-    CLS_EV    = ENT_EV
+    CLS_ICE      = ENT_ICE,
+    CLS_EV       = ENT_EV,
+    CLS_BIRD     = ENT_BIRD,
+    CLS_SONGBIRD = ENT_SONGBIRD,
+    CLS_CORVID   = ENT_CORVID
 } src_class_t;
 
 static const char *class_name(src_class_t c) {
@@ -248,6 +274,7 @@ typedef struct {
 
 static track_t g_drones[DOA_MAX_DRONE];
 static track_t g_vehicles[DOA_MAX_VEHICLE];
+static track_t g_birds[DOA_MAX_BIRD];
 static track_t g_walker;                 // single walking entity
 
 static float ang_diff_deg(float a, float b) {
@@ -343,6 +370,63 @@ static void vehicle_upsert(src_class_t cls, float az, float el, float conf,
     g_vehicles[i].match = match;
     g_vehicles[i].cadence_hz = mod_hz;
     g_vehicles[i].have_xy = false;
+}
+
+static int track_find_bird(float az, float el) {
+    int best = -1;
+    float best_d = DOA_GATE_DEG;
+    for (int i = 0; i < DOA_MAX_BIRD; i++) {
+        if (!g_birds[i].used) continue;
+        float d = ang_diff_deg(az, g_birds[i].az) + fabsf(el - g_birds[i].el);
+        if (d < best_d) { best_d = d; best = i; }
+    }
+    return best;
+}
+
+static int track_alloc_bird(void) {
+    for (int i = 0; i < DOA_MAX_BIRD; i++) if (!g_birds[i].used) return i;
+    int oldest = 0;
+    for (int i = 1; i < DOA_MAX_BIRD; i++)
+        if (g_birds[i].age > g_birds[oldest].age) oldest = i;
+    return oldest;
+}
+
+static void track_age_birds(void) {
+    for (int i = 0; i < DOA_MAX_BIRD; i++) {
+        if (!g_birds[i].used) continue;
+        g_birds[i].age++;
+        if (g_birds[i].age > DOA_TRACK_TTL) g_birds[i].used = false;
+    }
+}
+
+static uint32_t track_count_birds(void) {
+    uint32_t n = 0;
+    for (int i = 0; i < DOA_MAX_BIRD; i++) if (g_birds[i].used) n++;
+    return n;
+}
+
+static void bird_upsert(src_class_t cls, float az, float el, float conf,
+                        float lvl_db, uint32_t eid, float match, float chirp_hz) {
+    int i = track_find_bird(az, el);
+    if (i < 0) i = track_alloc_bird();
+    if (g_birds[i].used) {
+        g_birds[i].az = 0.7f * g_birds[i].az + 0.3f * az;
+        g_birds[i].el = 0.7f * g_birds[i].el + 0.3f * el;
+        g_birds[i].conf = 0.6f * g_birds[i].conf + 0.4f * conf;
+        g_birds[i].lvl_db = 0.6f * g_birds[i].lvl_db + 0.4f * lvl_db;
+    } else {
+        g_birds[i].az = az;
+        g_birds[i].el = el;
+        g_birds[i].conf = conf;
+        g_birds[i].lvl_db = lvl_db;
+    }
+    g_birds[i].used = true;
+    g_birds[i].cls = cls;
+    g_birds[i].age = 0;
+    g_birds[i].entity_id = eid;
+    g_birds[i].match = match;
+    g_birds[i].cadence_hz = chirp_hz;
+    g_birds[i].have_xy = false;
 }
 
 static bool ground_xy(float az_deg, float el_deg, float *x, float *y, float *rng) {
@@ -1046,12 +1130,188 @@ static void analyse_vehicle(uint32_t h) {
 }
 
 // ---------------------------------------------------------------------------
+// Bird song / calls (~2–8 kHz) — species heuristic + DOA position
+// ---------------------------------------------------------------------------
+typedef struct {
+    bool active;
+    uint32_t frames;
+    uint32_t quiet;
+    float az_sum, el_sum, conf_sum, lvl_sum;
+    float e_full, e_lo, e_hi;
+    float crest_sum;
+    float zcr_sum;   // zero-crossing rate proxy → chirp brightness
+} bird_bout_t;
+
+static bird_bout_t g_bird;
+
+typedef struct {
+    float e_full, e_lo, e_hi;
+    float crest;
+    float zcr;
+    float peak;
+} bird_feat_t;
+
+static bird_feat_t prepare_bird_band(bool active[6]) {
+    bird_feat_t f;
+    memset(&f, 0, sizeof(f));
+    float peak_all = 0.0f, rms_all = 0.0f;
+    for (int c = 0; c < 6; c++) {
+        float mean = 0.0f;
+        for (uint32_t n = 0; n < DOA_N; n++) mean += g_work[c][n];
+        mean /= (float)DOA_N;
+        biquad_mem_t hp = {0}, lp = {0}, lo = {0}, hi = {0};
+        float e_bp = 0.0f, e_lo = 0.0f, e_hi = 0.0f, peak = 0.0f;
+        float prev = 0.0f;
+        uint32_t zc = 0, zn = 0;
+        for (uint32_t n = 0; n < DOA_N; n++) {
+            float x = g_work[c][n] - mean;
+            float y = biquad_step(&k_hpf2000, &hp, x);
+            y = biquad_step(&k_lpf8000, &lp, y);
+            float yl = biquad_step(&k_lpf4000, &lo, y);
+            float yh = biquad_step(&k_hpf4000, &hi, y);
+            g_work[c][n] = y;
+            if (n >= DOA_FILT_SETTLE) {
+                e_bp += y * y;
+                e_lo += yl * yl;
+                e_hi += yh * yh;
+                float ay = fabsf(y);
+                if (ay > peak) peak = ay;
+                if ((y >= 0.0f && prev < 0.0f) || (y < 0.0f && prev >= 0.0f)) zc++;
+                prev = y;
+                zn++;
+            }
+        }
+        float e_corr = 0.0f;
+        for (uint32_t n = DOA_CORR_LO; n < DOA_CORR_HI; n++) e_corr += g_work[c][n] * g_work[c][n];
+        g_energy[c] = e_corr;
+        float rms = sqrtf(e_bp / (float)(DOA_N - DOA_FILT_SETTLE));
+        active[c] = rms > DOA_BIRD_RMS;
+        peak_all += peak;
+        rms_all += rms;
+        f.e_full += e_bp;
+        f.e_lo += e_lo;
+        f.e_hi += e_hi;
+        if (peak > f.peak) f.peak = peak;
+        if (c == 0 && zn) f.zcr = (float)zc / (float)zn;
+    }
+    f.crest = peak_all / (rms_all + 1e-6f);
+    if (f.crest < DOA_BIRD_CREST_MIN) {
+        for (int c = 0; c < 6; c++) active[c] = false;
+    }
+    return f;
+}
+
+static src_class_t classify_bird(float lo_r, float hi_r, float crest, float zcr, float lvl_db) {
+    float ss = 0.0f, sc = 0.0f, sg = 0.0f;
+    // Songbird: brighter (>4 kHz), higher ZCR, higher crest (tonal chirps).
+    if (hi_r > 0.40f) ss += 2.5f;
+    if (zcr > 0.12f) ss += 1.5f;
+    if (crest > 4.0f) ss += 1.0f;
+    // Corvid: more energy below 4 kHz, harsher / lower crest.
+    if (lo_r > 0.45f) sc += 2.5f;
+    if (zcr < 0.10f) sc += 1.0f;
+    if (lvl_db > -40.0f) sc += 0.5f;
+    // Generic bird fallback.
+    sg += 1.0f;
+    if (ss >= sc && ss >= sg) return CLS_SONGBIRD;
+    if (sc >= sg) return CLS_CORVID;
+    return CLS_BIRD;
+}
+
+static void finalize_bird_bout(void) {
+    if (!g_bird.active || g_bird.frames < DOA_BIRD_MIN_FRAMES) {
+        g_bird.active = false;
+        g_bird.frames = 0;
+        return;
+    }
+    float n = (float)g_bird.frames;
+    float az = g_bird.az_sum / n;
+    float el = g_bird.el_sum / n;
+    float conf = g_bird.conf_sum / n;
+    float lvl = g_bird.lvl_sum / n;
+    float lo_r = g_bird.e_lo / (g_bird.e_full + 1e-6f);
+    float hi_r = g_bird.e_hi / (g_bird.e_full + 1e-6f);
+    float crest = g_bird.crest_sum / n;
+    float zcr = g_bird.zcr_sum / n;
+    float chirp_hz = zcr * (DOA_FS * 0.5f) / 4000.0f; // rough brightness proxy
+
+    src_class_t cls = classify_bird(lo_r, hi_r, crest, zcr, lvl);
+    entity_sig_t sig;
+    sig.cadence_hz = chirp_hz;
+    sig.peak_db = lvl;
+    sig.low_ratio = lo_r;
+    sig.mid_ratio = 0.0f;
+    sig.high_ratio = hi_r;
+    sig.crest = crest;
+    sig.az_n = az / 360.0f;
+    sig.el_n = (el + 90.0f) / 180.0f;
+
+    float match = 0.0f;
+    uint32_t eid = entity_store_match_or_create((entity_class_t)cls, &sig, &match);
+    bird_upsert(cls, az, el, conf, lvl, eid, match, chirp_hz);
+    g_doa_entity_id = eid;
+    g_doa_nbird = track_count_birds();
+
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("ENTITY id=");
+    dbg_putu32(eid);
+    dbg_puts(" class=");
+    dbg_puts(class_name(cls));
+    dbg_puts(" frames=");
+    dbg_putu32(g_bird.frames);
+    dbg_puts(" match=");
+    put_f2(match);
+    dbg_puts(" az=");
+    put_f1(az);
+    dbg_puts(" el=");
+    put_f1(el);
+    dbg_puts(" (bird position)\n");
+    dbg_line_unlock(lock);
+
+    g_bird.active = false;
+    g_bird.frames = 0;
+    g_bird.quiet = 0;
+}
+
+static void analyse_bird(uint32_t h) {
+    bool active[6];
+    load_raw_window(h);
+    bird_feat_t feat = prepare_bird_band(active);
+    doa_fix_t r = solve_tdoa(active);
+    if (!r.ok) {
+        if (g_bird.active) {
+            g_bird.quiet++;
+            if (g_bird.quiet >= DOA_BIRD_GAP_FRAMES) finalize_bird_bout();
+        }
+        return;
+    }
+    // Birds are typically above/around the array — allow wide elevation.
+    if (!g_bird.active) {
+        memset(&g_bird, 0, sizeof(g_bird));
+        g_bird.active = true;
+    }
+    g_bird.quiet = 0;
+    g_bird.frames++;
+    g_bird.az_sum += r.az;
+    g_bird.el_sum += r.el;
+    g_bird.conf_sum += r.conf;
+    g_bird.lvl_sum += r.lvl_db;
+    g_bird.e_full += feat.e_full;
+    g_bird.e_lo += feat.e_lo;
+    g_bird.e_hi += feat.e_hi;
+    g_bird.crest_sum += feat.crest;
+    g_bird.zcr_sum += feat.zcr;
+    bird_upsert(CLS_NONE, r.az, r.el, r.conf, r.lvl_db, 0, 0.0f, 0.0f);
+}
+
+// ---------------------------------------------------------------------------
 // Reporting
 // ---------------------------------------------------------------------------
 static void report_tracks(void) {
     g_doa_ndrone = track_count_drones();
     g_doa_nwalker = g_walker.used ? 1u : 0u;
     g_doa_nvehicle = track_count_vehicles();
+    g_doa_nbird = track_count_birds();
     if (g_walker.used && g_walker.entity_id) g_doa_entity_id = g_walker.entity_id;
 
     uint32_t lock = dbg_line_lock();
@@ -1082,6 +1342,23 @@ static void report_tracks(void) {
         }
         dbg_putc('\n');
     }
+    for (int i = 0; i < DOA_MAX_BIRD; i++) {
+        if (!g_birds[i].used) continue;
+        dbg_puts("SRC class=");
+        dbg_puts(g_birds[i].cls == CLS_NONE ? "bird" : class_name(g_birds[i].cls));
+        dbg_puts(" entity=");
+        dbg_putu32(g_birds[i].entity_id);
+        dbg_puts(" az="); put_f1(g_birds[i].az);
+        dbg_puts(" el="); put_f1(g_birds[i].el);
+        dbg_puts(" conf="); put_f1(g_birds[i].conf);
+        dbg_puts(" lvl="); put_f1(g_birds[i].lvl_db);
+        dbg_puts("dB");
+        if (g_birds[i].cls != CLS_NONE) {
+            dbg_puts(" match=");
+            put_f2(g_birds[i].match);
+        }
+        dbg_puts(" pos=az/el\n");
+    }
     if (g_walker.used) {
         dbg_puts("SRC class=");
         dbg_puts(g_walker.cls == CLS_NONE ? "walker" : class_name(g_walker.cls));
@@ -1110,6 +1387,8 @@ static void report_tracks(void) {
     dbg_putu32(g_doa_ndrone);
     dbg_puts(" vehicle=");
     dbg_putu32(g_doa_nvehicle);
+    dbg_puts(" bird=");
+    dbg_putu32(g_doa_nbird);
     dbg_puts(" walker=");
     dbg_putu32(g_doa_nwalker);
     dbg_puts(" entity=");
@@ -1184,7 +1463,9 @@ static void doa_core1_main(void) {
     memset(&g_bout, 0, sizeof(g_bout));
     memset(&g_walker, 0, sizeof(g_walker));
     memset(&g_veh, 0, sizeof(g_veh));
+    memset(&g_bird, 0, sizeof(g_bird));
     memset(g_vehicles, 0, sizeof(g_vehicles));
+    memset(g_birds, 0, sizeof(g_birds));
 
     for (;;) {
         g_doa_iter++;
@@ -1202,6 +1483,7 @@ static void doa_core1_main(void) {
             last_drone = h;
             track_age_drones();
             track_age_vehicles();
+            track_age_birds();
             if (g_walker.used) {
                 g_walker.age++;
                 if (g_walker.age > DOA_TRACK_TTL) {
@@ -1211,6 +1493,7 @@ static void doa_core1_main(void) {
             }
             analyse_drone(h);
             analyse_vehicle(h);
+            analyse_bird(h);
             report_tracks();
         } else {
             tight_loop_contents();

--- a/doa.h
+++ b/doa.h
@@ -1,15 +1,15 @@
-// doa.h — multi-source DOA, walker/vehicle diarization. See doa.c.
+// doa.h — multi-source DOA + diarization. See doa.c / entity_store.h.
 #pragma once
 #include <stdint.h>
 
 void doa_ring_push(const int16_t s6[6]);
 void doa_start(void);
 
-// Diagnostics (heartbeat on core0).
-extern volatile uint32_t g_doa_out;        // UART report cycles
-extern volatile uint32_t g_doa_nactive;    // mics active in last drone-band solve
-extern volatile uint32_t g_doa_iter;       // core1 loop iterations (alive check)
-extern volatile uint32_t g_doa_ndrone;     // live drone tracks
-extern volatile uint32_t g_doa_nwalker;    // 0/1 — single walking entity track
-extern volatile uint32_t g_doa_nvehicle;   // live vehicle tracks (ICE/EV)
-extern volatile uint32_t g_doa_entity_id;  // gallery id of current/last entity (0=none)
+extern volatile uint32_t g_doa_out;
+extern volatile uint32_t g_doa_nactive;
+extern volatile uint32_t g_doa_iter;
+extern volatile uint32_t g_doa_ndrone;
+extern volatile uint32_t g_doa_nwalker;
+extern volatile uint32_t g_doa_nvehicle;
+extern volatile uint32_t g_doa_nbird;
+extern volatile uint32_t g_doa_entity_id;

--- a/entity_store.c
+++ b/entity_store.c
@@ -1,9 +1,11 @@
-// entity_store.c — persistent entity gallery in the last flash sector.
+// entity_store.c — RAM-first gallery with opportunistic ACID dual-slot flash.
 //
-// Layout: one 4 KiB sector at (PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE).
-// Reads are XIP (safe anytime). Writes use flash_safe_execute() so both cores
-// leave XIP; this may briefly glitch USB audio — saves are rare (new entity /
-// every 8th hit update).
+// Flash layout (end of primary flash):
+//   slot0 = PICO_FLASH_SIZE_BYTES - 2*FLASH_SECTOR_SIZE
+//   slot1 = PICO_FLASH_SIZE_BYTES - 1*FLASH_SECTOR_SIZE
+// Each slot holds one entity_blob_t. Load picks highest seq with valid CRC.
+// Saves never erase the active slot: write the inactive one page-by-page when
+// USB audio is idle (alt=0), then the new seq/CRC makes it the winner.
 #include "entity_store.h"
 #include "debug_io.h"
 #include "hardware/flash.h"
@@ -12,31 +14,41 @@
 #include "pico/stdlib.h"
 #include <string.h>
 #include <math.h>
+#include <ctype.h>
 
 #define ENTITY_MAGIC   0x45383648u  /* 'H68E' LE */
-#define ENTITY_VERSION 1u
+#define ENTITY_VERSION 2u
 
 #ifndef PICO_FLASH_SIZE_BYTES
 #error "PICO_FLASH_SIZE_BYTES must be defined by the board"
 #endif
 
-#define ENTITY_FLASH_OFF  (PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE)
+#define ENTITY_SLOT0_OFF  (PICO_FLASH_SIZE_BYTES - 2u * FLASH_SECTOR_SIZE)
+#define ENTITY_SLOT1_OFF  (PICO_FLASH_SIZE_BYTES - 1u * FLASH_SECTOR_SIZE)
 
-typedef struct {
-    uint32_t magic;
-    uint32_t version;
-    uint32_t next_id;
-    uint32_t count;
-    uint32_t crc;
-    uint32_t reserved[3];
-    entity_slot_t slots[ENTITY_STORE_MAX];
-} entity_blob_t;
+#define ENTITY_MATCH_MAX_DIST 0.55f
 
 static entity_slot_t g_slots[ENTITY_STORE_MAX];
 static uint32_t g_next_id = 1;
 static uint32_t g_count = 0;
+static uint32_t g_seq = 0;          // last successfully loaded/saved seq
+static uint32_t g_active_slot = 0;  // 0 or 1 — last known good flash slot
 static volatile bool g_dirty = false;
-static uint32_t g_save_countdown = 0;
+
+// Opportunistic save state machine (core0 only).
+typedef enum {
+    SAVE_IDLE = 0,
+    SAVE_ERASE,
+    SAVE_PROG
+} save_phase_t;
+
+static save_phase_t g_phase = SAVE_IDLE;
+static uint32_t g_save_slot = 0;
+static uint32_t g_prog_off = 0;
+static uint8_t g_stage[FLASH_SECTOR_SIZE];
+static entity_blob_t g_import_blob;
+static uint32_t g_import_pos = 0;
+static bool g_importing = false;
 
 static void put_f2(float v) {
     if (v < 0.0f) { dbg_putc('-'); v = -v; }
@@ -51,12 +63,15 @@ static void put_f2(float v) {
 
 const char *entity_class_name(entity_class_t c) {
     switch (c) {
-        case ENT_HUMAN: return "human";
-        case ENT_CAT:   return "cat";
-        case ENT_DOG:   return "dog";
-        case ENT_ICE:   return "ice";
-        case ENT_EV:    return "ev";
-        default:        return "none";
+        case ENT_HUMAN:    return "human";
+        case ENT_CAT:      return "cat";
+        case ENT_DOG:      return "dog";
+        case ENT_ICE:      return "ice";
+        case ENT_EV:       return "ev";
+        case ENT_BIRD:     return "bird";
+        case ENT_SONGBIRD: return "songbird";
+        case ENT_CORVID:   return "corvid";
+        default:           return "none";
     }
 }
 
@@ -70,7 +85,7 @@ static uint32_t crc32_update(uint32_t crc, const uint8_t *data, size_t len) {
     return ~crc;
 }
 
-static uint32_t blob_crc(const entity_blob_t *b) {
+uint32_t entity_blob_crc(const entity_blob_t *b) {
     entity_blob_t tmp = *b;
     tmp.crc = 0;
     return crc32_update(0, (const uint8_t *)&tmp, sizeof(tmp));
@@ -83,57 +98,73 @@ static void recount(void) {
     g_count = n;
 }
 
+static bool slot_valid(const entity_blob_t *b) {
+    if (b->magic != ENTITY_MAGIC) return false;
+    if (b->version != ENTITY_VERSION) return false;
+    if (b->count > ENTITY_STORE_MAX) return false;
+    return entity_blob_crc(b) == b->crc;
+}
+
 static void load_from_flash(void) {
-    const entity_blob_t *flash = (const entity_blob_t *)(XIP_BASE + ENTITY_FLASH_OFF);
+    const entity_blob_t *s0 = (const entity_blob_t *)(XIP_BASE + ENTITY_SLOT0_OFF);
+    const entity_blob_t *s1 = (const entity_blob_t *)(XIP_BASE + ENTITY_SLOT1_OFF);
     memset(g_slots, 0, sizeof(g_slots));
     g_next_id = 1;
     g_count = 0;
+    g_seq = 0;
+    g_active_slot = 0;
 
-    if (flash->magic != ENTITY_MAGIC || flash->version != ENTITY_VERSION) return;
-    if (flash->count > ENTITY_STORE_MAX) return;
-    if (blob_crc(flash) != flash->crc) return;
+    bool v0 = slot_valid(s0);
+    bool v1 = slot_valid(s1);
+    const entity_blob_t *best = NULL;
+    if (v0 && v1) {
+        best = (s1->seq >= s0->seq) ? s1 : s0;
+        g_active_slot = (best == s1) ? 1u : 0u;
+    } else if (v0) {
+        best = s0;
+        g_active_slot = 0;
+    } else if (v1) {
+        best = s1;
+        g_active_slot = 1;
+    }
+    if (!best) return;
 
-    memcpy(g_slots, flash->slots, sizeof(g_slots));
-    g_next_id = flash->next_id ? flash->next_id : 1;
+    memcpy(g_slots, best->slots, sizeof(g_slots));
+    g_next_id = best->next_id ? best->next_id : 1;
+    g_seq = best->seq;
     recount();
+}
+
+static void build_stage_blob(void) {
+    for (uint32_t i = 0; i < FLASH_SECTOR_SIZE; i++) g_stage[i] = 0xFFu;
+    entity_blob_t *b = (entity_blob_t *)g_stage;
+    memset(b, 0, sizeof(*b));
+    b->magic = ENTITY_MAGIC;
+    b->version = ENTITY_VERSION;
+    b->seq = g_seq + 1u;
+    b->next_id = g_next_id;
+    recount();
+    b->count = g_count;
+    memcpy(b->slots, g_slots, sizeof(g_slots));
+    b->crc = entity_blob_crc(b);
+}
+
+typedef struct { uint32_t off; uint32_t len; } flash_op_t;
+
+static void __not_in_flash_func(flash_erase_cb)(void *param) {
+    flash_op_t *op = (flash_op_t *)param;
+    flash_range_erase(op->off, FLASH_SECTOR_SIZE);
 }
 
 typedef struct {
-    entity_blob_t blob;
-} save_job_t;
+    uint32_t flash_off; // absolute
+    uint32_t stage_off; // into g_stage
+    uint32_t len;
+} flash_prog_t;
 
-// RAM staging buffer for the flash write callback (must not live in XIP).
-static uint8_t g_flash_pagebuf[FLASH_SECTOR_SIZE];
-
-static void __not_in_flash_func(save_job_fn)(void *param) {
-    save_job_t *job = (save_job_t *)param;
-    flash_range_erase(ENTITY_FLASH_OFF, FLASH_SECTOR_SIZE);
-    size_t nbytes = (sizeof(job->blob) + FLASH_PAGE_SIZE - 1u) & ~(FLASH_PAGE_SIZE - 1u);
-    // Fill unused bytes with erased state.
-    for (size_t i = 0; i < FLASH_SECTOR_SIZE; i++) g_flash_pagebuf[i] = 0xFFu;
-    // memcpy may live in flash — copy manually while XIP is offline.
-    const uint8_t *src = (const uint8_t *)&job->blob;
-    for (size_t i = 0; i < sizeof(job->blob); i++) g_flash_pagebuf[i] = src[i];
-    flash_range_program(ENTITY_FLASH_OFF, g_flash_pagebuf, nbytes);
-}
-
-static bool persist_now(void) {
-    save_job_t job;
-    memset(&job, 0, sizeof(job));
-    job.blob.magic = ENTITY_MAGIC;
-    job.blob.version = ENTITY_VERSION;
-    job.blob.next_id = g_next_id;
-    recount();
-    job.blob.count = g_count;
-    memcpy(job.blob.slots, g_slots, sizeof(g_slots));
-    job.blob.crc = blob_crc(&job.blob);
-
-    int rc = flash_safe_execute(save_job_fn, &job, 1000);
-    if (rc == PICO_OK) {
-        g_dirty = false;
-        return true;
-    }
-    return false;
+static void __not_in_flash_func(flash_prog_page_cb)(void *param) {
+    flash_prog_t *op = (flash_prog_t *)param;
+    flash_range_program(op->flash_off, &g_stage[op->stage_off], op->len);
 }
 
 void entity_store_core_init(void) {
@@ -143,18 +174,27 @@ void entity_store_core_init(void) {
 void entity_store_init(void) {
     load_from_flash();
     g_dirty = false;
+    g_phase = SAVE_IDLE;
+    g_importing = false;
 }
+
+bool entity_store_dirty(void) { return g_dirty; }
+bool entity_store_saving(void) { return g_phase != SAVE_IDLE; }
 
 void entity_store_dump_uart(void) {
     uint32_t lock = dbg_line_lock();
-    dbg_puts("=== entity store (flash) n=");
+    dbg_puts("=== entity store (RAM");
+    if (g_dirty) dbg_puts("+dirty");
+    dbg_puts(") n=");
     dbg_putu32(g_count);
     dbg_puts(" next_id=");
     dbg_putu32(g_next_id);
+    dbg_puts(" seq=");
+    dbg_putu32(g_seq);
+    dbg_puts(" flash_slot=");
+    dbg_putu32(g_active_slot);
     dbg_puts(" ===\n");
-    if (g_count == 0) {
-        dbg_puts("(empty — no persisted entities yet)\n");
-    }
+    if (g_count == 0) dbg_puts("(empty)\n");
     for (uint32_t i = 0; i < ENTITY_STORE_MAX; i++) {
         if (!g_slots[i].used) continue;
         const entity_slot_t *s = &g_slots[i];
@@ -174,7 +214,11 @@ void entity_store_dump_uart(void) {
         put_f2(s->sig.high_ratio);
         dbg_puts(" lvl=");
         put_f2(s->sig.peak_db);
-        dbg_puts("dB\n");
+        dbg_puts("dB az=");
+        put_f2(s->sig.az_n * 360.0f);
+        dbg_puts(" el=");
+        put_f2(s->sig.el_n * 180.0f - 90.0f);
+        dbg_putc('\n');
     }
     dbg_puts("=== end entity store ===\n");
     dbg_line_unlock(lock);
@@ -206,8 +250,6 @@ static void sig_ema(entity_sig_t *dst, const entity_sig_t *src, float a) {
     dst->el_n       = (1-a)*dst->el_n       + a*src->el_n;
 }
 
-#define ENTITY_MATCH_MAX_DIST 0.55f
-
 uint32_t entity_store_match_or_create(entity_class_t cls, const entity_sig_t *sig,
                                       float *match_out) {
     int best_i = -1;
@@ -219,7 +261,6 @@ uint32_t entity_store_match_or_create(entity_class_t cls, const entity_sig_t *si
         if (d < best_d) { best_d = d; best_i = (int)i; }
     }
 
-    bool created = false;
     uint32_t id;
     if (best_i >= 0) {
         sig_ema(&g_slots[best_i].sig, sig, 0.35f);
@@ -228,7 +269,6 @@ uint32_t entity_store_match_or_create(entity_class_t cls, const entity_sig_t *si
         *match_out = 1.0f - (best_d / ENTITY_MATCH_MAX_DIST);
         if (*match_out < 0.0f) *match_out = 0.0f;
         if (*match_out > 1.0f) *match_out = 1.0f;
-        // Persist occasionally on updates to limit flash wear.
         if ((g_slots[best_i].hits % 8u) == 0u) g_dirty = true;
     } else {
         int slot = -1;
@@ -242,7 +282,6 @@ uint32_t entity_store_match_or_create(entity_class_t cls, const entity_sig_t *si
             }
         }
         if (slot < 0) slot = oldest_i;
-
         id = g_next_id++;
         if (g_next_id == 0) g_next_id = 1;
         g_slots[slot].used = 1;
@@ -251,29 +290,152 @@ uint32_t entity_store_match_or_create(entity_class_t cls, const entity_sig_t *si
         g_slots[slot].hits = 1;
         g_slots[slot].sig = *sig;
         *match_out = 0.0f;
-        created = true;
         g_dirty = true;
         recount();
     }
+    // Never flash here — RAM only. entity_store_poll() persists later.
+    return id;
+}
 
-    if (g_dirty) {
-        // Defer a couple of loop iterations worth if called from hot path — but
-        // we persist immediately here; saves are rare.
-        if (!persist_now()) {
-            // Keep dirty; try again later via countdown from doa if needed.
-            g_save_countdown = 5;
-        } else if (created) {
+void entity_store_poll(bool usb_audio_idle) {
+    if (!usb_audio_idle) return;
+    if (g_importing) return;
+
+    if (g_phase == SAVE_IDLE) {
+        if (!g_dirty) return;
+        build_stage_blob();
+        g_save_slot = 1u - g_active_slot;
+        g_prog_off = 0;
+        g_phase = SAVE_ERASE;
+    }
+
+    if (g_phase == SAVE_ERASE) {
+        flash_op_t op = {
+            .off = (g_save_slot == 0u) ? ENTITY_SLOT0_OFF : ENTITY_SLOT1_OFF,
+            .len = FLASH_SECTOR_SIZE
+        };
+        int rc = flash_safe_execute(flash_erase_cb, &op, 200);
+        if (rc != PICO_OK) return; // retry next idle poll
+        g_phase = SAVE_PROG;
+        g_prog_off = 0;
+        return; // one flash op per poll
+    }
+
+    if (g_phase == SAVE_PROG) {
+        uint32_t base = (g_save_slot == 0u) ? ENTITY_SLOT0_OFF : ENTITY_SLOT1_OFF;
+        uint32_t need = (sizeof(entity_blob_t) + FLASH_PAGE_SIZE - 1u) & ~(FLASH_PAGE_SIZE - 1u);
+        if (g_prog_off >= need) {
+            // Commit: new slot is valid; update RAM bookkeeping.
+            entity_blob_t *b = (entity_blob_t *)g_stage;
+            g_seq = b->seq;
+            g_active_slot = g_save_slot;
+            g_dirty = false;
+            g_phase = SAVE_IDLE;
             uint32_t lock = dbg_line_lock();
-            dbg_puts("FLASH: saved entity id=");
-            dbg_putu32(id);
-            dbg_puts(" class=");
-            dbg_puts(entity_class_name(cls));
+            dbg_puts("FLASH: ACID commit seq=");
+            dbg_putu32(g_seq);
+            dbg_puts(" slot=");
+            dbg_putu32(g_active_slot);
+            dbg_puts(" n=");
+            dbg_putu32(g_count);
             dbg_putc('\n');
             dbg_line_unlock(lock);
+            return;
         }
+        flash_prog_t op = {
+            .flash_off = base + g_prog_off,
+            .stage_off = g_prog_off,
+            .len = FLASH_PAGE_SIZE
+        };
+        int rc = flash_safe_execute(flash_prog_page_cb, &op, 200);
+        if (rc != PICO_OK) return;
+        g_prog_off += FLASH_PAGE_SIZE;
+        // one page per poll
     }
-    (void)g_save_countdown;
-    return id;
+}
+
+void entity_store_export_uart(void) {
+    build_stage_blob(); // export current RAM (seq+1 preview OK for transfer)
+    // Re-stamp seq as current for export fidelity
+    entity_blob_t *b = (entity_blob_t *)g_stage;
+    b->seq = g_seq;
+    b->crc = entity_blob_crc(b);
+
+    uint32_t nbytes = (uint32_t)sizeof(entity_blob_t);
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("ENTBLOB BEGIN bytes=");
+    dbg_putu32(nbytes);
+    dbg_puts(" crc=");
+    dbg_puthex32(b->crc);
+    dbg_putc('\n');
+    const uint8_t *p = (const uint8_t *)b;
+    for (uint32_t i = 0; i < nbytes; i++) {
+        if ((i & 15u) == 0u) {
+            if (i) dbg_putc('\n');
+            dbg_puts("ENTHEX ");
+        } else {
+            dbg_putc(' ');
+        }
+        dbg_puthex8(p[i]);
+    }
+    dbg_putc('\n');
+    dbg_puts("ENTBLOB END\n");
+    dbg_line_unlock(lock);
+}
+
+bool entity_store_import_begin(void) {
+    if (g_phase != SAVE_IDLE) return false;
+    memset(&g_import_blob, 0, sizeof(g_import_blob));
+    g_import_pos = 0;
+    g_importing = true;
+    return true;
+}
+
+static int hex_nibble(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+bool entity_store_import_hex_line(const char *line) {
+    if (!g_importing) return false;
+    // Accept "ENTHEX aa bb cc ..." or raw hex bytes.
+    if (strncmp(line, "ENTHEX", 6) == 0) line += 6;
+    uint8_t *dst = (uint8_t *)&g_import_blob;
+    while (*line) {
+        while (*line == ' ' || *line == '\t') line++;
+        if (!*line) break;
+        int hi = hex_nibble(*line++);
+        if (hi < 0 || !*line) return false;
+        int lo = hex_nibble(*line++);
+        if (lo < 0) return false;
+        if (g_import_pos >= sizeof(g_import_blob)) return false;
+        dst[g_import_pos++] = (uint8_t)((hi << 4) | lo);
+    }
+    return true;
+}
+
+bool entity_store_import_end(void) {
+    if (!g_importing) return false;
+    g_importing = false;
+    if (g_import_pos < sizeof(entity_blob_t)) {
+        dbg_puts("ENT IMPORT ERR: short blob\n");
+        return false;
+    }
+    if (!slot_valid(&g_import_blob)) {
+        dbg_puts("ENT IMPORT ERR: bad magic/crc/version\n");
+        return false;
+    }
+    memcpy(g_slots, g_import_blob.slots, sizeof(g_slots));
+    g_next_id = g_import_blob.next_id ? g_import_blob.next_id : 1;
+    // Keep g_seq; next opportunistic save will write seq+1 (ACID).
+    recount();
+    g_dirty = true;
+    dbg_puts("ENT IMPORT OK n=");
+    dbg_putu32(g_count);
+    dbg_puts(" (RAM; flash pending idle)\n");
+    return true;
 }
 
 uint32_t entity_store_count(void) { return g_count; }

--- a/entity_store.h
+++ b/entity_store.h
@@ -1,4 +1,4 @@
-// entity_store.h — flash-backed gallery of recognised acoustic entities.
+// entity_store.h — RAM gallery + opportunistic ACID flash persistence.
 #pragma once
 #include <stdint.h>
 #include <stdbool.h>
@@ -6,51 +6,72 @@
 #define ENTITY_STORE_MAX 16
 
 typedef enum {
-    ENT_NONE  = 0,
-    ENT_HUMAN = 2,
-    ENT_CAT   = 3,
-    ENT_DOG   = 4,
-    ENT_ICE   = 5,   // ICE vehicle (combustion)
-    ENT_EV    = 6,   // electric vehicle
+    ENT_NONE     = 0,
+    ENT_HUMAN    = 2,
+    ENT_CAT      = 3,
+    ENT_DOG      = 4,
+    ENT_ICE      = 5,
+    ENT_EV       = 6,
+    ENT_BIRD     = 7,   // generic bird
+    ENT_SONGBIRD = 8,   // high/tonal chirps
+    ENT_CORVID   = 9,   // harsher / lower bird calls
 } entity_class_t;
 
-// Compact acoustic signature used for re-identification.
 typedef struct {
-    float cadence_hz;  // walkers: step rate; vehicles: envelope modulation proxy
+    float cadence_hz;
     float peak_db;
     float low_ratio;
     float high_ratio;
-    float mid_ratio;   // vehicles (and unused~0 for walkers)
+    float mid_ratio;
     float crest;
     float az_n;
     float el_n;
 } entity_sig_t;
 
 typedef struct {
-    uint32_t used;     // 0/1 (uint32 for flash alignment)
+    uint32_t used;
     uint32_t id;
-    uint32_t cls;      // entity_class_t
+    uint32_t cls;
     uint32_t hits;
     entity_sig_t sig;
 } entity_slot_t;
 
-// Load gallery from the last flash sector (or empty if blank/invalid).
-void entity_store_init(void);
+// On-wire / flash blob header + slots (version 2).
+typedef struct {
+    uint32_t magic;
+    uint32_t version;
+    uint32_t seq;       // monotonic; higher wins on load
+    uint32_t next_id;
+    uint32_t count;
+    uint32_t crc;       // CRC32 of whole blob with crc field zeroed
+    uint32_t reserved[2];
+    entity_slot_t slots[ENTITY_STORE_MAX];
+} entity_blob_t;
 
-// Print all persisted entities to the debug UART (call after dbg_init).
+void entity_store_core_init(void);
+void entity_store_init(void);                 // load best ACID slot into RAM
 void entity_store_dump_uart(void);
 
-// Match signature to gallery (same class) or create a new id.
-// match_out: 0..1 heuristic similarity (0 = new entity).
-// Persists to flash on create, and periodically on updates.
+// Match/create in RAM only — never blocks on flash.
 uint32_t entity_store_match_or_create(entity_class_t cls, const entity_sig_t *sig,
                                       float *match_out);
+
+// Opportunistic ACID save: call from core0 when USB audio is idle (alt=0).
+// Performs at most one flash erase or one 256 B page program per call.
+void entity_store_poll(bool usb_audio_idle);
+
+bool entity_store_dirty(void);
+bool entity_store_saving(void);
 
 uint32_t entity_store_count(void);
 uint32_t entity_store_next_id(void);
 const entity_slot_t *entity_store_slot(uint32_t index);
 
-const char *entity_class_name(entity_class_t c);
+// UART transfer helpers
+void entity_store_export_uart(void);          // ENTBLOB hex dump
+bool entity_store_import_begin(void);
+bool entity_store_import_hex_line(const char *line); // returns false on error
+bool entity_store_import_end(void);           // validate + load RAM, mark dirty
 
-// Must be called once on each core before flash writes (pico_flash).
-void entity_store_core_init(void);
+const char *entity_class_name(entity_class_t c);
+uint32_t entity_blob_crc(const entity_blob_t *b);

--- a/main.c
+++ b/main.c
@@ -707,7 +707,8 @@ static void dbg_heartbeat(uint32_t hb_count)
 #if !HET68_USB_DIAG
     {
         extern volatile uint32_t g_doa_out, g_doa_nactive, g_doa_iter;
-        extern volatile uint32_t g_doa_ndrone, g_doa_nwalker, g_doa_nvehicle, g_doa_entity_id;
+        extern volatile uint32_t g_doa_ndrone, g_doa_nwalker, g_doa_nvehicle;
+        extern volatile uint32_t g_doa_nbird, g_doa_entity_id;
         dbg_puts(" doa(out/act/iter)=");
         dbg_putu32(g_doa_out);
         dbg_putc('/');
@@ -718,10 +719,14 @@ static void dbg_heartbeat(uint32_t hb_count)
         dbg_putu32(g_doa_ndrone);
         dbg_puts(" veh=");
         dbg_putu32(g_doa_nvehicle);
+        dbg_puts(" bird=");
+        dbg_putu32(g_doa_nbird);
         dbg_puts(" walker=");
         dbg_putu32(g_doa_nwalker);
         dbg_puts(" entity=");
         dbg_putu32(g_doa_entity_id);
+        if (entity_store_dirty()) dbg_puts(" flash=dirty");
+        if (entity_store_saving()) dbg_puts(" flash=saving");
     }
 #endif
     dbg_putc('\n');
@@ -777,14 +782,15 @@ int main(void)
     dbg_puts("buzzer: PS1240 H-bridge GP6/GP7, 4kHz PN beacon\n");
 
 #if !HET68_USB_DIAG
-    // Flash-backed entity gallery (last sector). Dump before DOA starts.
+    // Flash-backed entity gallery (ACID dual-slot). Dump before DOA starts.
     entity_store_core_init();
     entity_store_init();
     entity_store_dump_uart();
+    dbg_puts("UART cmds: ENT LIST|EXPORT|IMPORT|END|HELP\n");
 
     // Direction-of-arrival on core1 (het68_launch_core1 resets core1 after SWD flash).
     doa_start();
-    dbg_puts("DOA: core1 drone+vehicle+walker (flash entity diarization)\n");
+    dbg_puts("DOA: drone+vehicle+bird+walker (opportunistic ACID flash)\n");
 #endif
 
     // Heartbeat LED. Boards whose LED is on a wireless module (e.g. Pico W /
@@ -802,6 +808,13 @@ int main(void)
     absolute_time_t next_heartbeat = make_timeout_time_ms(2000);
     uint32_t hb_count = 0;
 
+#if !HET68_USB_DIAG
+    // UART command line buffer (entity download/upload).
+    char cmd_buf[160];
+    uint32_t cmd_len = 0;
+    bool import_mode = false;
+#endif
+
     for (;;) {
         tud_task();
 
@@ -809,6 +822,52 @@ int main(void)
         if (tud_audio_mounted() && !i2s_started) {
             i2s_capture_init(AUDIO_SAMPLE_RATE);
             i2s_started = true;
+        }
+
+        // Opportunistic ACID flash: only when USB audio streaming is idle (alt=0).
+        entity_store_poll(dbg_last_alt == 0u);
+
+        // Non-blocking UART command parser.
+        while (dbg_rx_available()) {
+            int ch = dbg_getc();
+            if (ch < 0) break;
+            if (ch == '\r') continue;
+            if (ch == '\n') {
+                cmd_buf[cmd_len < sizeof(cmd_buf) ? cmd_len : (sizeof(cmd_buf) - 1u)] = '\0';
+                if (cmd_len > 0) {
+                    if (import_mode) {
+                        if (strcmp(cmd_buf, "ENT END") == 0 || strcmp(cmd_buf, "ENTBLOB END") == 0) {
+                            entity_store_import_end();
+                            import_mode = false;
+                        } else if (!entity_store_import_hex_line(cmd_buf)) {
+                            dbg_puts("ENT IMPORT ERR: bad hex line\n");
+                            import_mode = false;
+                        }
+                    } else if (strcmp(cmd_buf, "ENT LIST") == 0 || strcmp(cmd_buf, "ENT DUMP") == 0) {
+                        entity_store_dump_uart();
+                    } else if (strcmp(cmd_buf, "ENT EXPORT") == 0) {
+                        entity_store_export_uart();
+                    } else if (strcmp(cmd_buf, "ENT IMPORT") == 0) {
+                        if (entity_store_import_begin()) {
+                            import_mode = true;
+                            dbg_puts("ENT IMPORT: send ENTHEX lines, then ENT END\n");
+                        } else {
+                            dbg_puts("ENT IMPORT ERR: busy (flash save in progress)\n");
+                        }
+                    } else if (strcmp(cmd_buf, "ENT HELP") == 0 || strcmp(cmd_buf, "HELP") == 0) {
+                        dbg_puts("ENT LIST — print gallery\n");
+                        dbg_puts("ENT EXPORT — download hex blob\n");
+                        dbg_puts("ENT IMPORT — upload hex blob (ENTHEX … / ENT END)\n");
+                    } else if (strncmp(cmd_buf, "ENT", 3) == 0) {
+                        dbg_puts("ENT ?: try ENT HELP\n");
+                    }
+                }
+                cmd_len = 0;
+            } else if (cmd_len + 1u < sizeof(cmd_buf)) {
+                cmd_buf[cmd_len++] = (char)ch;
+            } else {
+                cmd_len = 0; // overflow — resync
+            }
         }
 #endif
         // Audio frames are produced in tud_audio_tx_done_pre_load_cb(), driven by


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Version **1.0.5** — USB-safe gallery persistence, UART transfer, and bird detection.

### Flash (ACID, no USB audio stall)
- Gallery updates stay in **RAM**; flash is never written from `match_or_create`.
- **Dual-slot** ACID layout (last two 4 KiB sectors): monotonic `seq` + CRC32; boot loads the newest valid blob (v2).
- `entity_store_poll()` runs from the main loop **only when USB alt=0**, at most one erase or one 256 B page program per call.

### UART download / upload
- `ENT LIST` — dump gallery
- `ENT EXPORT` — hex blob (`ENTHEX` lines)
- `ENT IMPORT` … `ENTHEX …` … `ENT END` — validate CRC, load RAM, opportunistic flash commit when idle
- `ENT HELP`

### Birds
- Parallel ~2–8 kHz front-end; up to **2** tracks.
- Classify **songbird** / **corvid** / **bird**; report DOA `az`/`el` as position; gallery diarization via `entity=` / `match=`.

### Notes
- Blob v1 → v2 upgrade clears the old single-sector gallery once.
- Species / re-ID remain best-effort heuristics.

## Test plan
- [x] `./build.sh` produces ELF/UF2
- [ ] Flash on Pico 2: stream USB audio; create entities; confirm no audible glitch while streaming; after idle, see `FLASH: ACID commit`
- [ ] UART: `ENT EXPORT` / `ENT IMPORT` round-trip
- [ ] Bird chirps: `SRC class=songbird|corvid|bird` with az/el

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

