### PR TITLE
1.0.6: wind inten/dir, UART CLI, timed DET log for NVR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ set(SRCS
     core1_launch.c
     doa.c
     entity_store.c
+    detection_log.c
+    het68_time.c
+    cli.c
 )
 
 add_executable(pico_6mic_soundcard ${SRCS})

--- a/README.md
+++ b/README.md
@@ -157,44 +157,37 @@ BOM and module layout: `wiring_and_bom.md`.
 
 Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
 
-* **Multi-source DOA (drone + vehicle + bird + single walker) with ACID flash diarization.**
-  core1 runs four parallel front-ends:
+* **Multi-source DOA (drone + vehicle + bird + walker + wind) with CLI + DET log.**
+  core1 runs parallel front-ends:
 
   | Class | Band | Cue | Tracks |
   |---|---|---|---|
-  | **drone** | ~800 Hz–6 kHz | continuous, wind gate, crest limit | up to **2** |
-  | **vehicle** | ~80 Hz–2.5 kHz | continuous pass-by → **ICE** / **EV** | up to **2** |
+  | **drone** | ~800 Hz–6 kHz | continuous, **wind gate kept**, crest limit | up to **2** |
+  | **wind** | LPF ~250 Hz | same energy as the gate → **intensity + steered az/el** | status |
+  | **vehicle** | ~80 Hz–2.5 kHz | pass-by → **ICE** / **EV** | up to **2** |
   | **bird** | ~2–8 kHz | chirp bout → songbird / corvid / bird | up to **2** |
-  | **walker** | ~150 Hz–600 Hz | footstep onset bout (≥3 steps) → human/cat/dog | **1** |
+  | **walker** | ~150 Hz–600 Hz | footstep bout (≥3 steps) → human/cat/dog | **1** |
 
-  Recognised entities live in a **RAM-first gallery** persisted with an **ACID
-  dual-slot** scheme in the last two 4 KiB flash sectors (`entity_store.c`, blob
-  v2: magic + seq + CRC32). `match_or_create` never touches flash; `entity_store_poll()`
-  erases/programs **one page at a time only when USB audio alt=0**, so streaming
-  is not stalled. On boot the gallery is listed on UART. Re-ID uses `entity=` +
-  heuristic `match=` 0–1. Birds report DOA `az`/`el` as position; walkers also get
-  ground `rng`/`x`/`y` (height: `edge·√3/2` or `HET68_DOA_HEIGHT_MM`).
+  **Entity gallery** (`entity_store`) = classification templates (ACID dual-slot,
+  last two flash sectors). **Detection log** (`detection_log`) = timed events in a
+  **separate** flash region (two sectors below the gallery) with `first_seen`,
+  `last_seen`, `occurrence`, `max_gap_ms`. DET timestamps are written **only after**
+  `TIME SYNC <unix>` since boot. `DET EXPORT` emits **JSON Lines** (`NVREVT`) for
+  smart-NVR event correlation.
 
-  UART gallery transfer: `ENT LIST` | `ENT EXPORT` | `ENT IMPORT` … `ENTHEX …` …
-  `ENT END` | `ENT HELP`. Import validates CRC then marks dirty; flash commit is
-  opportunistic when USB is idle.
-
-  UART example:
+  UART **CLI** (help on boot / first byte / USB mount): `HELP`, `TIME` /
+  `TIME SYNC`, `LOG ON|OFF`, `DET LIST|EXPORT|BACKUP|IMPORT|DEL|CLEAR`,
+  `ENT LIST|EXPORT|IMPORT`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
 
   ```
-  === entity store (flash) n=2 next_id=3 ===
-  ENT id=1 class=human hits=4 cadence=1.80Hz low=0.48 mid=0.00 high=0.14 lvl=-40.00dB
-  ENT id=2 class=songbird hits=1 cadence=4.20Hz low=0.20 mid=0.10 high=0.55 lvl=-36.00dB
-  === end entity store ===
+  SRC class=wind az=180.0 el=10.0 inten=-22.5dB
   SRC class=drone id=0 az=137.4 el=22.8 conf=0.7 lvl=-31.2dB
-  SRC class=songbird entity=2 az=210.0 el=35.0 conf=0.6 lvl=-36.0dB match=0.71 (bird position)
-  SRC class=human entity=1 az=45.0 el=-32.1 conf=0.5 lvl=-40.0dB match=0.82 cadence=1.80Hz rng=1.8m x=1.3 y=1.2
-  TRACKS drone=1 vehicle=0 bird=1 walker=1 entity=2
+  DET id=3 class=wind first=1720000000 last=1720000012 occ=8 max_gap_ms=400 az=180.0 el=10.0 inten=-22.5dB
+  TRACKS drone=1 vehicle=0 bird=0 walker=0 wind=1 entity=0
   ```
 
-  - Species / ICE·EV / re-ID are best-effort heuristics, not a trained model.
+  - Species / ICE·EV / wind direction / re-ID are best-effort heuristics.
   - Walker tracking assumes **one** walking entity at a time.
-  - Upgrading from gallery blob v1 clears the old single-sector store once.
 
 * **Array geometry.** A cube standing on a vertex, **512 mm** edge. Mics 1–3 are
   the three upper faces (mic 1 = north, then +120°, +240° azimuth, all at +35.26°

--- a/TEST_SCENARIOS_1.0.6.md
+++ b/TEST_SCENARIOS_1.0.6.md
@@ -1,0 +1,110 @@
+# Test scenarios — het68 1.0.6
+
+Practical checks for wind intensity/direction, UART CLI, time-synced detection
+log, and NVR JSON export. Use Debug Probe UART (115200 8N1 on Grove UART0).
+
+## Setup
+
+1. Flash `het68-1.0.6-pico2.uf2` (or local `./build.sh` artifact).
+2. Open serial: `picocom -b 115200 /dev/ttyACM1` (or the Debug Probe UART device).
+3. On boot (and on first UART byte / USB mount) you should see `=== het68 CLI ===`.
+4. Host with USB audio optional for wind/drone tests; flash commits only when
+   USB alt setting is 0 (stream idle).
+
+---
+
+## A. CLI help + logging gate
+
+| Step | Action | Expect |
+|------|--------|--------|
+| A1 | Power on / open UART | Help banner printed |
+| A2 | Send `HELP` | Same help text |
+| A3 | `LOG OFF` then wait ~2 s with activity | No `SRC` / `ENTITY` / `TRACKS` lines; heartbeat still appears with `log=off` |
+| A4 | `LOG ON` | Live `SRC` lines resume |
+
+---
+
+## B. Time sync gate for DET timestamps
+
+| Step | Action | Expect |
+|------|--------|--------|
+| B1 | Boot, do **not** sync. Create noise (walk/drone). `DET LIST` | `time_synced=0`, empty or only previously flashed events; **no new** timed rows |
+| B2 | `TIME` | `synced=0 epoch=0` |
+| B3 | `TIME SYNC $(date +%s)` (or paste a unix epoch ≥ 1700000000) | `TIME OK epoch=…` |
+| B4 | `TIME` | `synced=1` and increasing epoch |
+| B5 | Trigger a classifiable event (walker bout / bird / vehicle / drone) | `DET LIST` shows `first=` / `last=` close to wall clock, `occ≥1`, `max_gap_ms` |
+
+---
+
+## C. Detection CRUD + NVR export
+
+| Step | Action | Expect |
+|------|--------|--------|
+| C1 | After B3–B5, `DET LIST` | Human-readable `DET id=… class=… first=… last=… occ=… max_gap_ms=…` |
+| C2 | `DET EXPORT` | Block `NVREVT BEGIN` … JSON lines … `NVREVT END` |
+| C3 | Validate one JSON line | Fields: `v`, `device=het68`, `type=detection`, `id`, `class`, `first_seen`, `last_seen`, `occurrence`, `max_gap_ms`, `az`, `el`, `intensity_db`, `conf` |
+| C4 | `DET DEL <id>` | `DET DEL OK`; id gone from `DET LIST` |
+| C5 | `DET CLEAR` | All rows cleared |
+| C6 | `DET BACKUP` → save hex → `DET IMPORT` / `DETHEX` / `DET END` | Round-trip restore (`DET IMPORT OK`) |
+| C7 | Stop USB audio (alt=0), wait | `FLASH: DET ACID commit` when dirty |
+
+### NVR correlation sketch
+
+Pipe export into a smart NVR / SIEM as JSON Lines:
+
+```bash
+# Example: capture DET EXPORT output, strip NVREVT markers, feed correlator
+grep '^{' uart.log | jq -c 'select(.type=="detection")'
+```
+
+Join on `first_seen`/`last_seen` (unix seconds) with camera events ± few seconds;
+use `class` + `az`/`el` as side-channel metadata (not pixel coordinates).
+
+---
+
+## D. Wind filter still active + intensity/direction
+
+| Step | Action | Expect |
+|------|--------|--------|
+| D1 | Quiet indoor, fan **off** | Heartbeat `wind=0`; no `SRC class=wind` |
+| D2 | Blow air / point a fan at the array (prefer one face) | `SRC class=wind az=… el=… inten=…dB` (if `LOG ON`); heartbeat `wind=1@…dB` |
+| D3 | Rotate fan / blow from opposite side | Reported `az` moves toward that face (± coarse, energy steering) |
+| D4 | Strong wind + soft drone-band noise | Drone mics still wind-gated (`DOA_WIND_RATIO`); false drone tracks should not explode |
+| D5 | After `TIME SYNC`, repeat D2 | `DET LIST` contains `class=wind` with `inten`, `az`/`el`, rising `occ` |
+
+---
+
+## E. Entity gallery still separate from DET
+
+| Step | Action | Expect |
+|------|--------|--------|
+| E1 | `ENT LIST` vs `DET LIST` | Gallery = classification templates; DET = timed events |
+| E2 | `ENT EXPORT` / `ENT IMPORT` | Unchanged gallery hex protocol |
+| E3 | `DET CLEAR` | Does **not** wipe `ENT` gallery |
+
+---
+
+## F. USB audio + opportunistic flash (regression)
+
+| Step | Action | Expect |
+|------|--------|--------|
+| F1 | Start 6ch USB capture on host | Continuous audio, no multi-second dropouts |
+| F2 | While streaming, generate new entities/dets | Heartbeat may show `flash=dirty`; **no** erase/program until alt=0 |
+| F3 | Stop capture (alt=0) | `FLASH: ACID commit` and/or `FLASH: DET ACID commit` |
+| F4 | Reboot | Gallery + DET log reload from flash |
+
+---
+
+## G. Quick smoke script (host)
+
+```bash
+# After serial is open and firmware booted:
+printf 'HELP\n' > /dev/ttyACM1
+printf 'TIME SYNC %s\n' "$(date +%s)" > /dev/ttyACM1
+printf 'LOG ON\n' > /dev/ttyACM1
+# … generate acoustic events …
+printf 'DET LIST\n' > /dev/ttyACM1
+printf 'DET EXPORT\n' > /dev/ttyACM1
+```
+
+Pass criteria for a lab smoke: A1–A4, B1–B5, C1–C3, D1–D2, F1–F3.

--- a/cli.c
+++ b/cli.c
@@ -1,0 +1,201 @@
+// cli.c — UART command-line interface for gallery + detection log + time/log.
+#include "cli.h"
+#include "debug_io.h"
+#include "entity_store.h"
+#include "detection_log.h"
+#include "het68_time.h"
+#include <string.h>
+
+static char g_buf[192];
+static uint32_t g_len;
+static bool g_ent_import;
+static bool g_det_import;
+static bool g_help_shown;
+
+void cli_print_help(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("=== het68 CLI ===\n");
+    dbg_puts("HELP                 — this help\n");
+    dbg_puts("TIME                 — show clock / sync status\n");
+    dbg_puts("TIME SYNC <unix>     — sync wall clock (required for DET timestamps)\n");
+    dbg_puts("LOG ON | LOG OFF     — enable/disable SRC/ENTITY stdout logging\n");
+    dbg_puts("LOG                  — show log status\n");
+    dbg_puts("DET LIST             — list saved detections\n");
+    dbg_puts("DET EXPORT           — NVR JSON Lines (NVREVT)\n");
+    dbg_puts("DET BACKUP           — hex blob download (DETBLOB)\n");
+    dbg_puts("DET IMPORT           — upload hex blob (DETHEX … / DET END)\n");
+    dbg_puts("DET DEL <id>         — delete one detection\n");
+    dbg_puts("DET CLEAR            — delete all detections\n");
+    dbg_puts("ENT LIST             — entity gallery (classification templates)\n");
+    dbg_puts("ENT EXPORT|IMPORT    — gallery hex blob transfer\n");
+    dbg_puts("Note: DET timestamps only after TIME SYNC since boot.\n");
+    dbg_puts("=================\n");
+    dbg_line_unlock(lock);
+}
+
+void cli_init(void) {
+    g_len = 0;
+    g_ent_import = false;
+    g_det_import = false;
+    g_help_shown = false;
+}
+
+void cli_on_connect(void) {
+    if (g_help_shown) return;
+    g_help_shown = true;
+    cli_print_help();
+}
+
+static uint32_t parse_u32(const char *s) {
+    uint32_t v = 0;
+    while (*s == ' ') s++;
+    while (*s >= '0' && *s <= '9') {
+        v = v * 10u + (uint32_t)(*s - '0');
+        s++;
+    }
+    return v;
+}
+
+static void handle_line(char *line) {
+    // Trim trailing spaces
+    size_t n = strlen(line);
+    while (n && (line[n - 1] == ' ' || line[n - 1] == '\t')) line[--n] = '\0';
+
+    if (g_ent_import) {
+        if (strcmp(line, "ENT END") == 0 || strcmp(line, "ENTBLOB END") == 0) {
+            entity_store_import_end();
+            g_ent_import = false;
+        } else if (!entity_store_import_hex_line(line)) {
+            dbg_puts("ENT IMPORT ERR: bad hex line\n");
+            g_ent_import = false;
+        }
+        return;
+    }
+    if (g_det_import) {
+        if (strcmp(line, "DET END") == 0 || strcmp(line, "DETBLOB END") == 0) {
+            detection_log_import_end();
+            g_det_import = false;
+        } else if (!detection_log_import_hex_line(line)) {
+            dbg_puts("DET IMPORT ERR: bad hex line\n");
+            g_det_import = false;
+        }
+        return;
+    }
+
+    if (line[0] == '\0' || strcmp(line, "HELP") == 0 || strcmp(line, "?") == 0) {
+        cli_print_help();
+        return;
+    }
+
+    if (strcmp(line, "TIME") == 0) {
+        het68_time_dump_uart();
+        return;
+    }
+    if (strncmp(line, "TIME SYNC ", 10) == 0) {
+        uint32_t ep = parse_u32(line + 10);
+        if (het68_time_sync(ep)) {
+            dbg_puts("TIME OK epoch=");
+            dbg_putu32(het68_time_epoch_sec());
+            dbg_putc('\n');
+        } else {
+            dbg_puts("TIME ERR: need unix epoch >= 1700000000\n");
+        }
+        return;
+    }
+
+    if (strcmp(line, "LOG") == 0) {
+        dbg_puts("LOG stdout=");
+        dbg_puts(dbg_log_enabled() ? "on" : "off");
+        dbg_putc('\n');
+        return;
+    }
+    if (strcmp(line, "LOG ON") == 0) {
+        dbg_log_set(true);
+        dbg_puts("LOG stdout=on\n");
+        return;
+    }
+    if (strcmp(line, "LOG OFF") == 0) {
+        dbg_log_set(false);
+        dbg_puts("LOG stdout=off\n");
+        return;
+    }
+
+    if (strcmp(line, "DET LIST") == 0 || strcmp(line, "DET DUMP") == 0) {
+        detection_log_list_uart();
+        return;
+    }
+    if (strcmp(line, "DET EXPORT") == 0) {
+        detection_log_export_nvr();
+        return;
+    }
+    if (strcmp(line, "DET BACKUP") == 0) {
+        detection_log_export_hex();
+        return;
+    }
+    if (strcmp(line, "DET IMPORT") == 0) {
+        if (detection_log_import_begin()) {
+            g_det_import = true;
+            dbg_puts("DET IMPORT: send DETHEX lines, then DET END\n");
+        } else {
+            dbg_puts("DET IMPORT ERR: busy\n");
+        }
+        return;
+    }
+    if (strncmp(line, "DET DEL ", 8) == 0) {
+        uint32_t id = parse_u32(line + 8);
+        if (detection_log_delete_id(id)) dbg_puts("DET DEL OK\n");
+        else dbg_puts("DET DEL ERR: not found\n");
+        return;
+    }
+    if (strcmp(line, "DET CLEAR") == 0 || strcmp(line, "DET DELETE ALL") == 0) {
+        detection_log_clear();
+        dbg_puts("DET CLEAR OK\n");
+        return;
+    }
+
+    if (strcmp(line, "ENT LIST") == 0 || strcmp(line, "ENT DUMP") == 0) {
+        entity_store_dump_uart();
+        return;
+    }
+    if (strcmp(line, "ENT EXPORT") == 0) {
+        entity_store_export_uart();
+        return;
+    }
+    if (strcmp(line, "ENT IMPORT") == 0) {
+        if (entity_store_import_begin()) {
+            g_ent_import = true;
+            dbg_puts("ENT IMPORT: send ENTHEX lines, then ENT END\n");
+        } else {
+            dbg_puts("ENT IMPORT ERR: busy\n");
+        }
+        return;
+    }
+    if (strcmp(line, "ENT HELP") == 0) {
+        cli_print_help();
+        return;
+    }
+
+    if (strncmp(line, "DET", 3) == 0 || strncmp(line, "ENT", 3) == 0 ||
+        strncmp(line, "TIME", 4) == 0 || strncmp(line, "LOG", 3) == 0) {
+        dbg_puts("?: unknown command — HELP\n");
+    }
+}
+
+void cli_rx_byte(int ch) {
+    if (ch < 0) return;
+    // First byte from host → treat as "connected" and show help once.
+    if (!g_help_shown) cli_on_connect();
+
+    if (ch == '\r') return;
+    if (ch == '\n') {
+        g_buf[g_len < sizeof(g_buf) ? g_len : (sizeof(g_buf) - 1u)] = '\0';
+        handle_line(g_buf);
+        g_len = 0;
+        return;
+    }
+    if (g_len + 1u < sizeof(g_buf)) {
+        g_buf[g_len++] = (char)ch;
+    } else {
+        g_len = 0;
+    }
+}

--- a/cli.h
+++ b/cli.h
@@ -1,0 +1,12 @@
+// cli.h — simple UART CLI (help, time, log, DET, ENT).
+#pragma once
+#include <stdbool.h>
+
+void cli_init(void);
+void cli_print_help(void);
+
+// Feed one received byte (non-blocking). Handles line assembly + commands.
+void cli_rx_byte(int ch);
+
+// Call once after USB mount / first attach to show help.
+void cli_on_connect(void);

--- a/debug_io.c
+++ b/debug_io.c
@@ -26,6 +26,7 @@
 // Cross-core line lock. Claimed once in dbg_init(); both cores serialise full
 // debug lines through it so UART output never interleaves.
 static spin_lock_t *dbg_spin;
+static volatile bool g_log_enabled = true;
 
 void dbg_init(void) {
     uart_init(uart_default, 115200);
@@ -34,7 +35,11 @@ void dbg_init(void) {
     if (!dbg_spin) {
         dbg_spin = spin_lock_init((uint)spin_lock_claim_unused(true));
     }
+    g_log_enabled = true;
 }
+
+void dbg_log_set(bool enabled) { g_log_enabled = enabled; }
+bool dbg_log_enabled(void) { return g_log_enabled; }
 
 uint32_t dbg_line_lock(void) {
     return dbg_spin ? spin_lock_blocking(dbg_spin) : 0u;

--- a/debug_io.h
+++ b/debug_io.h
@@ -21,6 +21,10 @@ int dbg_getc(void);   // -1 if none
 uint32_t dbg_line_lock(void);
 void dbg_line_unlock(uint32_t saved);
 
+// Optional telemetry gate (SRC / ENTITY / TRACKS). CLI replies always print.
+void dbg_log_set(bool enabled);
+bool dbg_log_enabled(void);
+
 // Single-character checkpoint macro: writes 'X\n' to UART.
 // Usable from any .c file that includes this header.
 #define DBG_CP(letter) do { dbg_putc(letter); dbg_putc('\n'); } while(0)

--- a/detection_log.c
+++ b/detection_log.c
@@ -1,0 +1,479 @@
+// detection_log.c — RAM-first detection events with opportunistic ACID flash.
+//
+// Flash layout (below entity gallery slots):
+//   slot0 = PICO_FLASH_SIZE_BYTES - 4*FLASH_SECTOR_SIZE
+//   slot1 = PICO_FLASH_SIZE_BYTES - 3*FLASH_SECTOR_SIZE
+#include "detection_log.h"
+#include "het68_time.h"
+#include "debug_io.h"
+#include "hardware/flash.h"
+#include "hardware/sync.h"
+#include "pico/flash.h"
+#include "pico/stdlib.h"
+#include <string.h>
+#include <math.h>
+#include <ctype.h>
+
+#define DET_MAGIC   0x4C383648u  /* 'H68L' LE — Log */
+#define DET_VERSION 1u
+#define DET_GATE_DEG 35.0f
+#define DET_MERGE_MAX_GAP_MS 120000u  // 2 min — beyond this, open a new event
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#error "PICO_FLASH_SIZE_BYTES must be defined by the board"
+#endif
+
+#define DET_SLOT0_OFF  (PICO_FLASH_SIZE_BYTES - 4u * FLASH_SECTOR_SIZE)
+#define DET_SLOT1_OFF  (PICO_FLASH_SIZE_BYTES - 3u * FLASH_SECTOR_SIZE)
+
+static det_slot_t g_slots[DET_LOG_MAX];
+static uint32_t g_next_id = 1;
+static uint32_t g_count = 0;
+static uint32_t g_seq = 0;
+static uint32_t g_active_slot = 0;
+static volatile bool g_dirty = false;
+
+typedef enum { SAVE_IDLE = 0, SAVE_ERASE, SAVE_PROG } save_phase_t;
+static save_phase_t g_phase = SAVE_IDLE;
+static uint32_t g_save_slot = 0;
+static uint32_t g_prog_off = 0;
+static uint8_t g_stage[FLASH_SECTOR_SIZE];
+static det_blob_t g_import_blob;
+static uint32_t g_import_pos = 0;
+static bool g_importing = false;
+
+static void put_f1(float v) {
+    if (v < 0.0f) { dbg_putc('-'); v = -v; }
+    uint32_t ip = (uint32_t)v;
+    uint32_t fp = (uint32_t)((v - (float)ip) * 10.0f + 0.5f);
+    if (fp >= 10u) { ip++; fp = 0u; }
+    dbg_putu32(ip);
+    dbg_putc('.');
+    dbg_putu32(fp);
+}
+
+const char *det_class_name(det_class_t c) {
+    switch (c) {
+        case DET_WIND:     return "wind";
+        case DET_DRONE:    return "drone";
+        case DET_VEHICLE:  return "vehicle";
+        case DET_ICE:      return "ice";
+        case DET_EV:       return "ev";
+        case DET_WALKER:   return "walker";
+        case DET_HUMAN:    return "human";
+        case DET_CAT:      return "cat";
+        case DET_DOG:      return "dog";
+        case DET_BIRD:     return "bird";
+        case DET_SONGBIRD: return "songbird";
+        case DET_CORVID:   return "corvid";
+        default:           return "none";
+    }
+}
+
+det_class_t det_class_from_name(const char *name) {
+    if (!name) return DET_NONE;
+    for (int c = 1; c <= (int)DET_CORVID; c++) {
+        if (strcmp(name, det_class_name((det_class_t)c)) == 0)
+            return (det_class_t)c;
+    }
+    return DET_NONE;
+}
+
+static uint32_t crc32_update(uint32_t crc, const uint8_t *data, size_t len) {
+    crc = ~crc;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; b++)
+            crc = (crc & 1u) ? ((crc >> 1) ^ 0xEDB88320u) : (crc >> 1);
+    }
+    return ~crc;
+}
+
+static uint32_t blob_crc(const det_blob_t *b) {
+    det_blob_t tmp = *b;
+    tmp.crc = 0;
+    return crc32_update(0, (const uint8_t *)&tmp, sizeof(tmp));
+}
+
+static void recount(void) {
+    uint32_t n = 0;
+    for (uint32_t i = 0; i < DET_LOG_MAX; i++)
+        if (g_slots[i].used) n++;
+    g_count = n;
+}
+
+static bool slot_valid(const det_blob_t *b) {
+    if (b->magic != DET_MAGIC) return false;
+    if (b->version != DET_VERSION) return false;
+    if (b->count > DET_LOG_MAX) return false;
+    return blob_crc(b) == b->crc;
+}
+
+static float ang_diff_deg(float a, float b) {
+    float d = a - b;
+    while (d > 180.0f) d -= 360.0f;
+    while (d < -180.0f) d += 360.0f;
+    return fabsf(d);
+}
+
+static void build_stage_blob(void) {
+    memset(g_stage, 0xFF, sizeof(g_stage));
+    det_blob_t *b = (det_blob_t *)g_stage;
+    b->magic = DET_MAGIC;
+    b->version = DET_VERSION;
+    b->seq = g_seq + 1u;
+    b->next_id = g_next_id;
+    b->count = g_count;
+    memcpy(b->slots, g_slots, sizeof(g_slots));
+    b->crc = blob_crc(b);
+}
+
+typedef struct { uint32_t off; uint32_t len; } flash_op_t;
+typedef struct { uint32_t flash_off; uint32_t stage_off; uint32_t len; } flash_prog_t;
+
+static void __not_in_flash_func(flash_erase_cb)(void *arg) {
+    flash_op_t *op = (flash_op_t *)arg;
+    flash_range_erase(op->off, op->len);
+}
+
+static void __not_in_flash_func(flash_prog_page_cb)(void *arg) {
+    flash_prog_t *op = (flash_prog_t *)arg;
+    flash_range_program(op->flash_off, g_stage + op->stage_off, op->len);
+}
+
+void detection_log_core_init(void) {
+    // flash_safe_execute needs both cores cooperating; entity_store already enables.
+}
+
+void detection_log_init(void) {
+    memset(g_slots, 0, sizeof(g_slots));
+    g_next_id = 1;
+    g_count = 0;
+    g_seq = 0;
+    g_active_slot = 0;
+    g_dirty = false;
+    g_phase = SAVE_IDLE;
+    g_importing = false;
+
+    const det_blob_t *best = NULL;
+    uint32_t best_seq = 0;
+    uint32_t best_slot = 0;
+    for (uint32_t s = 0; s < 2; s++) {
+        uint32_t off = (s == 0u) ? DET_SLOT0_OFF : DET_SLOT1_OFF;
+        const det_blob_t *b = (const det_blob_t *)(XIP_BASE + off);
+        if (!slot_valid(b)) continue;
+        if (!best || b->seq >= best_seq) {
+            best = b;
+            best_seq = b->seq;
+            best_slot = s;
+        }
+    }
+    if (best) {
+        memcpy(g_slots, best->slots, sizeof(g_slots));
+        g_next_id = best->next_id ? best->next_id : 1;
+        g_seq = best->seq;
+        g_active_slot = best_slot;
+        recount();
+    }
+}
+
+bool detection_log_dirty(void) { return g_dirty; }
+bool detection_log_saving(void) { return g_phase != SAVE_IDLE; }
+uint32_t detection_log_count(void) { return g_count; }
+
+const det_slot_t *detection_log_slot(uint32_t index) {
+    if (index >= DET_LOG_MAX) return NULL;
+    return &g_slots[index];
+}
+
+uint32_t detection_log_observe(det_class_t cls, uint32_t entity_id,
+                               float az, float el, float intensity_db, float conf) {
+    if (cls == DET_NONE) return 0;
+    if (!het68_time_synced()) return 0; // timestamps required — skip until TIME SYNC
+
+    uint32_t now = het68_time_epoch_sec();
+    uint32_t now_ms = het68_time_epoch_ms();
+
+    int best = -1;
+    float best_d = 1e9f;
+    for (int i = 0; i < DET_LOG_MAX; i++) {
+        if (!g_slots[i].used) continue;
+        if (g_slots[i].cls != (uint32_t)cls) continue;
+        if (entity_id && g_slots[i].entity_id && g_slots[i].entity_id != entity_id) continue;
+        float d = ang_diff_deg(az, g_slots[i].az) + fabsf(el - g_slots[i].el);
+        if (d < best_d) { best_d = d; best = i; }
+    }
+
+    if (best >= 0 && best_d <= DET_GATE_DEG) {
+        uint32_t prev_ms = g_slots[best].last_seen * 1000u;
+        uint32_t gap_ms = (now_ms > prev_ms) ? (now_ms - prev_ms) : 0u;
+        if (gap_ms > DET_MERGE_MAX_GAP_MS) {
+            best = -1; // too stale — new event
+        } else {
+            if (gap_ms > g_slots[best].max_gap_ms)
+                g_slots[best].max_gap_ms = gap_ms;
+            g_slots[best].last_seen = now;
+            g_slots[best].occurrence++;
+            g_slots[best].az = 0.7f * g_slots[best].az + 0.3f * az;
+            g_slots[best].el = 0.7f * g_slots[best].el + 0.3f * el;
+            if (intensity_db > g_slots[best].intensity_db)
+                g_slots[best].intensity_db = intensity_db;
+            g_slots[best].conf = 0.6f * g_slots[best].conf + 0.4f * conf;
+            if (entity_id) g_slots[best].entity_id = entity_id;
+            g_dirty = true;
+            return g_slots[best].id;
+        }
+    }
+
+    int free_i = -1;
+    int oldest = -1;
+    uint32_t oldest_last = 0xFFFFFFFFu;
+    for (int i = 0; i < DET_LOG_MAX; i++) {
+        if (!g_slots[i].used) { free_i = i; break; }
+        if (g_slots[i].last_seen < oldest_last) {
+            oldest_last = g_slots[i].last_seen;
+            oldest = i;
+        }
+    }
+    int slot = (free_i >= 0) ? free_i : oldest;
+    if (slot < 0) return 0;
+
+    uint32_t id = g_next_id++;
+    if (g_next_id == 0) g_next_id = 1;
+    g_slots[slot].used = 1;
+    g_slots[slot].id = id;
+    g_slots[slot].cls = (uint32_t)cls;
+    g_slots[slot].entity_id = entity_id;
+    g_slots[slot].first_seen = now;
+    g_slots[slot].last_seen = now;
+    g_slots[slot].occurrence = 1;
+    g_slots[slot].max_gap_ms = 0;
+    g_slots[slot].az = az;
+    g_slots[slot].el = el;
+    g_slots[slot].intensity_db = intensity_db;
+    g_slots[slot].conf = conf;
+    recount();
+    g_dirty = true;
+    return id;
+}
+
+bool detection_log_delete_id(uint32_t id) {
+    for (int i = 0; i < DET_LOG_MAX; i++) {
+        if (g_slots[i].used && g_slots[i].id == id) {
+            memset(&g_slots[i], 0, sizeof(g_slots[i]));
+            recount();
+            g_dirty = true;
+            return true;
+        }
+    }
+    return false;
+}
+
+void detection_log_clear(void) {
+    memset(g_slots, 0, sizeof(g_slots));
+    g_count = 0;
+    g_dirty = true;
+}
+
+void detection_log_poll(bool usb_audio_idle) {
+    if (!usb_audio_idle) return;
+    if (g_importing) return;
+
+    if (g_phase == SAVE_IDLE) {
+        if (!g_dirty) return;
+        build_stage_blob();
+        g_save_slot = 1u - g_active_slot;
+        g_prog_off = 0;
+        g_phase = SAVE_ERASE;
+    }
+
+    if (g_phase == SAVE_ERASE) {
+        flash_op_t op = {
+            .off = (g_save_slot == 0u) ? DET_SLOT0_OFF : DET_SLOT1_OFF,
+            .len = FLASH_SECTOR_SIZE
+        };
+        int rc = flash_safe_execute(flash_erase_cb, &op, 200);
+        if (rc != PICO_OK) return;
+        g_phase = SAVE_PROG;
+        g_prog_off = 0;
+        return;
+    }
+
+    if (g_phase == SAVE_PROG) {
+        uint32_t base = (g_save_slot == 0u) ? DET_SLOT0_OFF : DET_SLOT1_OFF;
+        uint32_t need = (sizeof(det_blob_t) + FLASH_PAGE_SIZE - 1u) & ~(FLASH_PAGE_SIZE - 1u);
+        if (g_prog_off >= need) {
+            det_blob_t *b = (det_blob_t *)g_stage;
+            g_seq = b->seq;
+            g_active_slot = g_save_slot;
+            g_dirty = false;
+            g_phase = SAVE_IDLE;
+            uint32_t lock = dbg_line_lock();
+            dbg_puts("FLASH: DET ACID commit seq=");
+            dbg_putu32(g_seq);
+            dbg_puts(" n=");
+            dbg_putu32(g_count);
+            dbg_putc('\n');
+            dbg_line_unlock(lock);
+            return;
+        }
+        flash_prog_t op = {
+            .flash_off = base + g_prog_off,
+            .stage_off = g_prog_off,
+            .len = FLASH_PAGE_SIZE
+        };
+        int rc = flash_safe_execute(flash_prog_page_cb, &op, 200);
+        if (rc != PICO_OK) return;
+        g_prog_off += FLASH_PAGE_SIZE;
+    }
+}
+
+static void print_slot_line(const det_slot_t *s) {
+    dbg_puts("DET id=");
+    dbg_putu32(s->id);
+    dbg_puts(" class=");
+    dbg_puts(det_class_name((det_class_t)s->cls));
+    dbg_puts(" entity=");
+    dbg_putu32(s->entity_id);
+    dbg_puts(" first=");
+    dbg_putu32(s->first_seen);
+    dbg_puts(" last=");
+    dbg_putu32(s->last_seen);
+    dbg_puts(" occ=");
+    dbg_putu32(s->occurrence);
+    dbg_puts(" max_gap_ms=");
+    dbg_putu32(s->max_gap_ms);
+    dbg_puts(" az="); put_f1(s->az);
+    dbg_puts(" el="); put_f1(s->el);
+    dbg_puts(" inten="); put_f1(s->intensity_db);
+    dbg_puts("dB conf="); put_f1(s->conf);
+    dbg_putc('\n');
+}
+
+void detection_log_list_uart(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("=== detection log n=");
+    dbg_putu32(g_count);
+    dbg_puts(" next_id=");
+    dbg_putu32(g_next_id);
+    dbg_puts(" time_synced=");
+    dbg_puts(het68_time_synced() ? "1" : "0");
+    dbg_puts(" ===\n");
+    for (uint32_t i = 0; i < DET_LOG_MAX; i++) {
+        if (g_slots[i].used) print_slot_line(&g_slots[i]);
+    }
+    dbg_puts("=== end detection log ===\n");
+    dbg_line_unlock(lock);
+}
+
+void detection_log_export_nvr(void) {
+    // JSON Lines — one object per detection for smart-NVR event correlation.
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("NVREVT BEGIN device=het68 v=1\n");
+    for (uint32_t i = 0; i < DET_LOG_MAX; i++) {
+        const det_slot_t *s = &g_slots[i];
+        if (!s->used) continue;
+        dbg_puts("{\"v\":1,\"device\":\"het68\",\"type\":\"detection\",\"id\":");
+        dbg_putu32(s->id);
+        dbg_puts(",\"class\":\"");
+        dbg_puts(det_class_name((det_class_t)s->cls));
+        dbg_puts("\",\"entity_id\":");
+        dbg_putu32(s->entity_id);
+        dbg_puts(",\"first_seen\":");
+        dbg_putu32(s->first_seen);
+        dbg_puts(",\"last_seen\":");
+        dbg_putu32(s->last_seen);
+        dbg_puts(",\"occurrence\":");
+        dbg_putu32(s->occurrence);
+        dbg_puts(",\"max_gap_ms\":");
+        dbg_putu32(s->max_gap_ms);
+        dbg_puts(",\"az\":"); put_f1(s->az);
+        dbg_puts(",\"el\":"); put_f1(s->el);
+        dbg_puts(",\"intensity_db\":"); put_f1(s->intensity_db);
+        dbg_puts(",\"conf\":"); put_f1(s->conf);
+        dbg_puts("}\n");
+    }
+    dbg_puts("NVREVT END\n");
+    dbg_line_unlock(lock);
+}
+
+void detection_log_export_hex(void) {
+    build_stage_blob();
+    det_blob_t *b = (det_blob_t *)g_stage;
+    b->seq = g_seq;
+    b->crc = blob_crc(b);
+
+    uint32_t nbytes = (uint32_t)sizeof(det_blob_t);
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("DETBLOB BEGIN bytes=");
+    dbg_putu32(nbytes);
+    dbg_puts(" crc=");
+    dbg_puthex32(b->crc);
+    dbg_putc('\n');
+    const uint8_t *p = (const uint8_t *)b;
+    for (uint32_t i = 0; i < nbytes; i++) {
+        if ((i & 15u) == 0u) {
+            if (i) dbg_putc('\n');
+            dbg_puts("DETHEX ");
+        } else {
+            dbg_putc(' ');
+        }
+        dbg_puthex8(p[i]);
+    }
+    dbg_putc('\n');
+    dbg_puts("DETBLOB END\n");
+    dbg_line_unlock(lock);
+}
+
+bool detection_log_import_begin(void) {
+    if (g_phase != SAVE_IDLE) return false;
+    memset(&g_import_blob, 0, sizeof(g_import_blob));
+    g_import_pos = 0;
+    g_importing = true;
+    return true;
+}
+
+static int hex_nibble(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+bool detection_log_import_hex_line(const char *line) {
+    if (!g_importing) return false;
+    if (strncmp(line, "DETHEX", 6) == 0) line += 6;
+    uint8_t *dst = (uint8_t *)&g_import_blob;
+    while (*line) {
+        while (*line == ' ' || *line == '\t') line++;
+        if (!*line) break;
+        int hi = hex_nibble(*line++);
+        if (hi < 0 || !*line) return false;
+        int lo = hex_nibble(*line++);
+        if (lo < 0) return false;
+        if (g_import_pos >= sizeof(g_import_blob)) return false;
+        dst[g_import_pos++] = (uint8_t)((hi << 4) | lo);
+    }
+    return true;
+}
+
+bool detection_log_import_end(void) {
+    if (!g_importing) return false;
+    g_importing = false;
+    if (g_import_pos < sizeof(det_blob_t)) {
+        dbg_puts("DET IMPORT ERR: short blob\n");
+        return false;
+    }
+    if (!slot_valid(&g_import_blob)) {
+        dbg_puts("DET IMPORT ERR: bad magic/crc/version\n");
+        return false;
+    }
+    memcpy(g_slots, g_import_blob.slots, sizeof(g_slots));
+    g_next_id = g_import_blob.next_id ? g_import_blob.next_id : 1;
+    recount();
+    g_dirty = true;
+    dbg_puts("DET IMPORT OK n=");
+    dbg_putu32(g_count);
+    dbg_puts(" (RAM; flash pending idle)\n");
+    return true;
+}

--- a/detection_log.h
+++ b/detection_log.h
@@ -1,0 +1,79 @@
+// detection_log.h — event log separate from entity gallery (NVR correlation).
+//
+// Timestamps (first_seen / last_seen) are recorded only after TIME SYNC since boot.
+// Flash: ACID dual-slot in the two sectors just below the entity gallery.
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#define DET_LOG_MAX 32
+
+// Detection classes (orthogonal to entity gallery templates).
+typedef enum {
+    DET_NONE     = 0,
+    DET_WIND     = 1,
+    DET_DRONE    = 2,
+    DET_VEHICLE  = 3,
+    DET_ICE      = 4,
+    DET_EV       = 5,
+    DET_WALKER   = 6,
+    DET_HUMAN    = 7,
+    DET_CAT      = 8,
+    DET_DOG      = 9,
+    DET_BIRD     = 10,
+    DET_SONGBIRD = 11,
+    DET_CORVID   = 12,
+} det_class_t;
+
+typedef struct {
+    uint32_t used;
+    uint32_t id;
+    uint32_t cls;
+    uint32_t entity_id;     // optional gallery link (0 = none)
+    uint32_t first_seen;    // unix epoch seconds
+    uint32_t last_seen;     // unix epoch seconds
+    uint32_t occurrence;    // times refreshed / seen
+    uint32_t max_gap_ms;    // largest gap between consecutive observations
+    float az;
+    float el;
+    float intensity_db;     // peak intensity (dBFS-ish)
+    float conf;
+} det_slot_t;
+
+typedef struct {
+    uint32_t magic;
+    uint32_t version;
+    uint32_t seq;
+    uint32_t next_id;
+    uint32_t count;
+    uint32_t crc;
+    uint32_t reserved[2];
+    det_slot_t slots[DET_LOG_MAX];
+} det_blob_t;
+
+void detection_log_core_init(void);
+void detection_log_init(void);
+void detection_log_poll(bool usb_audio_idle);
+
+bool detection_log_dirty(void);
+bool detection_log_saving(void);
+
+// Observe a live detection. No-op (returns 0) until TIME SYNC since boot.
+// Merges into an existing slot when class (+ optional entity) and angle match.
+uint32_t detection_log_observe(det_class_t cls, uint32_t entity_id,
+                               float az, float el, float intensity_db, float conf);
+
+uint32_t detection_log_count(void);
+const det_slot_t *detection_log_slot(uint32_t index);
+bool detection_log_delete_id(uint32_t id);
+void detection_log_clear(void);
+
+void detection_log_list_uart(void);
+void detection_log_export_nvr(void);   // JSON Lines for smart NVR
+void detection_log_export_hex(void);   // DETBLOB hex for backup/restore
+bool detection_log_import_begin(void);
+bool detection_log_import_hex_line(const char *line);
+bool detection_log_import_end(void);
+
+const char *det_class_name(det_class_t c);
+det_class_t det_class_from_name(const char *name);

--- a/doa.c
+++ b/doa.c
@@ -1,15 +1,18 @@
-// doa.c — multi-source 3D DOA on core1 with drone + walker + vehicle diarization.
+// doa.c — multi-source 3D DOA on core1 with drone + walker + vehicle + bird + wind.
 //
 // core0 pushes each 6-channel frame via doa_ring_push() from the USB/I2S feed.
 // core1 runs:
 //   • drone band (~800 Hz–6 kHz): continuous TDOA, up to 2 tracks (primary + SIC)
+//   • wind (LPF ~250 Hz): keep wind gate for drones; also report intensity + direction
 //   • walker band (~150–600 Hz): single walking entity — onset bout → human/cat/dog
 //   • vehicle band (~80 Hz–2.5 kHz): pass-by → ICE vs EV
-// Entity signatures persist in flash via entity_store (re-ID across reboots).
+//   • bird band (~2–8 kHz): songbird / corvid / bird
+// Entity signatures → entity_store; timed events → detection_log (after TIME SYNC).
 //
 // core1 must be launched with het68_launch_core1() (see core1_launch.c).
 #include "doa.h"
 #include "entity_store.h"
+#include "detection_log.h"
 #include "core1_launch.h"
 #include "debug_io.h"
 #include "pico/stdlib.h"
@@ -75,6 +78,7 @@ static float MIC_POS[6][3];
 
 #define DOA_DRONE_RMS       2.5f
 #define DOA_WIND_RATIO      0.35f
+#define DOA_WIND_RMS_MIN    12.0f   // report wind when LF energy exceeds this
 #define DOA_WALK_RMS        3.0f
 #define DOA_WALK_CREST      3.5f
 #define DOA_DRONE_CREST_MAX 6.0f
@@ -117,6 +121,10 @@ volatile uint32_t g_doa_nwalker;
 volatile uint32_t g_doa_nvehicle;
 volatile uint32_t g_doa_nbird;
 volatile uint32_t g_doa_entity_id;
+volatile uint32_t g_doa_wind;
+volatile float    g_doa_wind_az;
+volatile float    g_doa_wind_el;
+volatile float    g_doa_wind_db;
 
 void doa_ring_push(const int16_t s6[6]) {
     uint32_t h = g_head;
@@ -259,6 +267,25 @@ static const char *class_name(src_class_t c) {
     if (c == CLS_NONE) return "none";
     return entity_class_name((entity_class_t)c);
 }
+
+static det_class_t det_from_src(src_class_t c) {
+    switch (c) {
+        case CLS_DRONE:    return DET_DRONE;
+        case CLS_HUMAN:    return DET_HUMAN;
+        case CLS_CAT:      return DET_CAT;
+        case CLS_DOG:      return DET_DOG;
+        case CLS_ICE:      return DET_ICE;
+        case CLS_EV:       return DET_EV;
+        case CLS_BIRD:     return DET_BIRD;
+        case CLS_SONGBIRD: return DET_SONGBIRD;
+        case CLS_CORVID:   return DET_CORVID;
+        default:           return DET_NONE;
+    }
+}
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 typedef struct {
     bool used;
@@ -600,9 +627,45 @@ static void cancel_direction(const float dir[3], int ref) {
     }
 }
 
-static float prepare_drone_band(bool active[6]) {
+// Wind estimate from per-mic LF energy (same LPF250 used by the drone wind gate).
+typedef struct {
+    bool present;
+    float az;
+    float el;
+    float intensity_db;
+    float e_wind[6];
+} wind_est_t;
+
+static wind_est_t estimate_wind_from_energy(const float e_wind[6]) {
+    wind_est_t w;
+    memset(&w, 0, sizeof(w));
+    float wx = 0.0f, wy = 0.0f, wz = 0.0f, esum = 0.0f;
+    for (int c = 0; c < 6; c++) {
+        w.e_wind[c] = e_wind[c];
+        float e = e_wind[c];
+        esum += e;
+        wx += MIC_DIR[c][0] * e;
+        wy += MIC_DIR[c][1] * e;
+        wz += MIC_DIR[c][2] * e;
+    }
+    float nsam = (float)(DOA_N - DOA_FILT_SETTLE);
+    float rms = sqrtf(esum / (6.0f * nsam + 1e-6f));
+    w.intensity_db = 20.0f * log10f((rms + 1e-6f) / 32768.0f);
+    w.present = (rms >= DOA_WIND_RMS_MIN);
+    float norm = sqrtf(wx * wx + wy * wy + wz * wz) + 1e-9f;
+    float dx = wx / norm, dy = wy / norm, dz = wz / norm;
+    float az = atan2f(dy, dx) * (180.0f / (float)M_PI);
+    if (az < 0.0f) az += 360.0f;
+    float el = asinf(fmaxf(-1.0f, fminf(1.0f, dz))) * (180.0f / (float)M_PI);
+    w.az = az;
+    w.el = el;
+    return w;
+}
+
+static float prepare_drone_band(bool active[6], wind_est_t *wind_out) {
     int nactive = 0;
     float crest_num = 0.0f, crest_den = 0.0f;
+    float e_wind_ch[6];
     for (int c = 0; c < 6; c++) {
         float mean = 0.0f;
         for (uint32_t n = 0; n < DOA_N; n++) mean += g_work[c][n];
@@ -622,15 +685,18 @@ static float prepare_drone_band(bool active[6]) {
                 if (ay > peak) peak = ay;
             }
         }
+        e_wind_ch[c] = e_wind;
         float e_corr = 0.0f;
         for (uint32_t n = DOA_CORR_LO; n < DOA_CORR_HI; n++) e_corr += g_work[c][n] * g_work[c][n];
         g_energy[c] = e_corr;
+        // Keep wind gate: reject mic if LF wind energy dominates the drone band.
         float rms = sqrtf(e_bp / (float)(DOA_N - DOA_FILT_SETTLE));
         active[c] = (rms > DOA_DRONE_RMS) && (e_bp >= DOA_WIND_RATIO * (e_wind + 1e-6f));
         if (active[c]) nactive++;
         crest_num += peak;
         crest_den += rms + 1e-6f;
     }
+    if (wind_out) *wind_out = estimate_wind_from_energy(e_wind_ch);
     g_doa_nactive = (uint32_t)nactive;
     float crest = crest_num / crest_den;
     if (crest > DOA_DRONE_CREST_MAX) {
@@ -806,23 +872,27 @@ static void finalize_bout_if_needed(uint32_t now, bool force) {
     g_doa_entity_id = eid;
     g_doa_nwalker = 1;
 
-    uint32_t lock = dbg_line_lock();
-    dbg_puts("ENTITY id=");
-    dbg_putu32(eid);
-    dbg_puts(" class=");
-    dbg_puts(class_name(cls));
-    dbg_puts(" steps=");
-    dbg_putu32(g_bout.n_steps);
-    dbg_puts(" cadence=");
-    put_f2(sig.cadence_hz);
-    dbg_puts("Hz match=");
-    put_f2(match);
-    dbg_puts(" low=");
-    put_f2(sig.low_ratio);
-    dbg_puts(" high=");
-    put_f2(sig.high_ratio);
-    dbg_putc('\n');
-    dbg_line_unlock(lock);
+    (void)detection_log_observe(det_from_src(cls), eid, az, el, lvl, conf);
+
+    if (dbg_log_enabled()) {
+        uint32_t lock = dbg_line_lock();
+        dbg_puts("ENTITY id=");
+        dbg_putu32(eid);
+        dbg_puts(" class=");
+        dbg_puts(class_name(cls));
+        dbg_puts(" steps=");
+        dbg_putu32(g_bout.n_steps);
+        dbg_puts(" cadence=");
+        put_f2(sig.cadence_hz);
+        dbg_puts("Hz match=");
+        put_f2(match);
+        dbg_puts(" low=");
+        put_f2(sig.low_ratio);
+        dbg_puts(" high=");
+        put_f2(sig.high_ratio);
+        dbg_putc('\n');
+        dbg_line_unlock(lock);
+    }
 
     g_bout.active = false;
     g_bout.n_steps = 0;
@@ -1057,26 +1127,29 @@ static void finalize_vehicle_bout(void) {
     vehicle_upsert(cls, az, el, conf, lvl, eid, match, mod_hz);
     g_doa_entity_id = eid;
     g_doa_nvehicle = track_count_vehicles();
+    (void)detection_log_observe(det_from_src(cls), eid, az, el, lvl, conf);
 
-    uint32_t lock = dbg_line_lock();
-    dbg_puts("ENTITY id=");
-    dbg_putu32(eid);
-    dbg_puts(" class=");
-    dbg_puts(class_name(cls));
-    dbg_puts(" frames=");
-    dbg_putu32(g_veh.frames);
-    dbg_puts(" match=");
-    put_f2(match);
-    dbg_puts(" low=");
-    put_f2(low_r);
-    dbg_puts(" mid=");
-    put_f2(mid_r);
-    dbg_puts(" high=");
-    put_f2(high_r);
-    dbg_puts(" daz=");
-    put_f1(daz);
-    dbg_puts("deg\n");
-    dbg_line_unlock(lock);
+    if (dbg_log_enabled()) {
+        uint32_t lock = dbg_line_lock();
+        dbg_puts("ENTITY id=");
+        dbg_putu32(eid);
+        dbg_puts(" class=");
+        dbg_puts(class_name(cls));
+        dbg_puts(" frames=");
+        dbg_putu32(g_veh.frames);
+        dbg_puts(" match=");
+        put_f2(match);
+        dbg_puts(" low=");
+        put_f2(low_r);
+        dbg_puts(" mid=");
+        put_f2(mid_r);
+        dbg_puts(" high=");
+        put_f2(high_r);
+        dbg_puts(" daz=");
+        put_f1(daz);
+        dbg_puts("deg\n");
+        dbg_line_unlock(lock);
+    }
 
     g_veh.active = false;
     g_veh.frames = 0;
@@ -1251,22 +1324,25 @@ static void finalize_bird_bout(void) {
     bird_upsert(cls, az, el, conf, lvl, eid, match, chirp_hz);
     g_doa_entity_id = eid;
     g_doa_nbird = track_count_birds();
+    (void)detection_log_observe(det_from_src(cls), eid, az, el, lvl, conf);
 
-    uint32_t lock = dbg_line_lock();
-    dbg_puts("ENTITY id=");
-    dbg_putu32(eid);
-    dbg_puts(" class=");
-    dbg_puts(class_name(cls));
-    dbg_puts(" frames=");
-    dbg_putu32(g_bird.frames);
-    dbg_puts(" match=");
-    put_f2(match);
-    dbg_puts(" az=");
-    put_f1(az);
-    dbg_puts(" el=");
-    put_f1(el);
-    dbg_puts(" (bird position)\n");
-    dbg_line_unlock(lock);
+    if (dbg_log_enabled()) {
+        uint32_t lock = dbg_line_lock();
+        dbg_puts("ENTITY id=");
+        dbg_putu32(eid);
+        dbg_puts(" class=");
+        dbg_puts(class_name(cls));
+        dbg_puts(" frames=");
+        dbg_putu32(g_bird.frames);
+        dbg_puts(" match=");
+        put_f2(match);
+        dbg_puts(" az=");
+        put_f1(az);
+        dbg_puts(" el=");
+        put_f1(el);
+        dbg_puts(" (bird position)\n");
+        dbg_line_unlock(lock);
+    }
 
     g_bird.active = false;
     g_bird.frames = 0;
@@ -1314,7 +1390,49 @@ static void report_tracks(void) {
     g_doa_nbird = track_count_birds();
     if (g_walker.used && g_walker.entity_id) g_doa_entity_id = g_walker.entity_id;
 
+    // Persist live tracks into DET log (only after TIME SYNC — see detection_log).
+    for (int i = 0; i < DOA_MAX_DRONE; i++) {
+        if (!g_drones[i].used) continue;
+        (void)detection_log_observe(DET_DRONE, 0, g_drones[i].az, g_drones[i].el,
+                                    g_drones[i].lvl_db, g_drones[i].conf);
+    }
+    for (int i = 0; i < DOA_MAX_VEHICLE; i++) {
+        if (!g_vehicles[i].used || g_vehicles[i].cls == CLS_NONE) continue;
+        (void)detection_log_observe(det_from_src(g_vehicles[i].cls), g_vehicles[i].entity_id,
+                                    g_vehicles[i].az, g_vehicles[i].el,
+                                    g_vehicles[i].lvl_db, g_vehicles[i].conf);
+    }
+    for (int i = 0; i < DOA_MAX_BIRD; i++) {
+        if (!g_birds[i].used || g_birds[i].cls == CLS_NONE) continue;
+        (void)detection_log_observe(det_from_src(g_birds[i].cls), g_birds[i].entity_id,
+                                    g_birds[i].az, g_birds[i].el,
+                                    g_birds[i].lvl_db, g_birds[i].conf);
+    }
+    if (g_walker.used && g_walker.cls != CLS_NONE) {
+        (void)detection_log_observe(det_from_src(g_walker.cls), g_walker.entity_id,
+                                    g_walker.az, g_walker.el,
+                                    g_walker.lvl_db, g_walker.conf);
+    }
+    if (g_doa_wind) {
+        (void)detection_log_observe(DET_WIND, 0, g_doa_wind_az, g_doa_wind_el,
+                                    g_doa_wind_db, 0.5f);
+    }
+
+    if (!dbg_log_enabled()) {
+        g_doa_out++;
+        return;
+    }
+
     uint32_t lock = dbg_line_lock();
+    if (g_doa_wind) {
+        dbg_puts("SRC class=wind az=");
+        put_f1(g_doa_wind_az);
+        dbg_puts(" el=");
+        put_f1(g_doa_wind_el);
+        dbg_puts(" inten=");
+        put_f1(g_doa_wind_db);
+        dbg_puts("dB\n");
+    }
     for (int i = 0; i < DOA_MAX_DRONE; i++) {
         if (!g_drones[i].used) continue;
         dbg_puts("SRC class=drone id=");
@@ -1391,6 +1509,8 @@ static void report_tracks(void) {
     dbg_putu32(g_doa_nbird);
     dbg_puts(" walker=");
     dbg_putu32(g_doa_nwalker);
+    dbg_puts(" wind=");
+    dbg_putu32(g_doa_wind);
     dbg_puts(" entity=");
     dbg_putu32(g_doa_entity_id);
     dbg_putc('\n');
@@ -1403,8 +1523,20 @@ static void report_tracks(void) {
 // ---------------------------------------------------------------------------
 static void analyse_drone(uint32_t h) {
     bool active[6];
+    wind_est_t wind;
     load_raw_window(h);
-    (void)prepare_drone_band(active);
+    (void)prepare_drone_band(active, &wind);
+
+    // Keep wind gate for drones; also publish wind intensity + steered direction.
+    if (wind.present) {
+        g_doa_wind = 1;
+        g_doa_wind_az = wind.az;
+        g_doa_wind_el = wind.el;
+        g_doa_wind_db = wind.intensity_db;
+    } else {
+        g_doa_wind = 0;
+    }
+
     doa_fix_t primary = solve_tdoa(active);
     if (!primary.ok) return;
 
@@ -1451,6 +1583,7 @@ static bool doa_core1_verify(void) {
 static void doa_core1_main(void) {
     // Allow the other core to lock us out during flash_safe_execute saves.
     entity_store_core_init();
+    detection_log_core_init();
 
     for (int i = 0; i < 6; i++)
         for (int k = 0; k < 3; k++) MIC_POS[i][k] = MIC_DIR[i][k] * DOA_FACE_R;
@@ -1466,6 +1599,7 @@ static void doa_core1_main(void) {
     memset(&g_bird, 0, sizeof(g_bird));
     memset(g_vehicles, 0, sizeof(g_vehicles));
     memset(g_birds, 0, sizeof(g_birds));
+    g_doa_wind = 0;
 
     for (;;) {
         g_doa_iter++;

--- a/doa.h
+++ b/doa.h
@@ -13,3 +13,7 @@ extern volatile uint32_t g_doa_nwalker;
 extern volatile uint32_t g_doa_nvehicle;
 extern volatile uint32_t g_doa_nbird;
 extern volatile uint32_t g_doa_entity_id;
+extern volatile uint32_t g_doa_wind;          // 1 when wind currently detected
+extern volatile float    g_doa_wind_az;
+extern volatile float    g_doa_wind_el;
+extern volatile float    g_doa_wind_db;       // intensity dB

--- a/het68_time.c
+++ b/het68_time.c
@@ -1,0 +1,55 @@
+// het68_time.c — epoch clock anchored by UART TIME SYNC.
+#include "het68_time.h"
+#include "debug_io.h"
+#include "pico/stdlib.h"
+
+static bool g_synced;
+static uint32_t g_epoch0;           // unix seconds at sync instant
+static absolute_time_t g_at0;       // pico time at sync instant
+static uint32_t g_synced_at_epoch;  // copy of g_epoch0 for status
+
+void het68_time_init(void) {
+    g_synced = false;
+    g_epoch0 = 0;
+    g_synced_at_epoch = 0;
+    g_at0 = get_absolute_time();
+}
+
+bool het68_time_sync(uint32_t unix_epoch_sec) {
+    if (unix_epoch_sec < 1700000000u) return false; // reject nonsense / year < 2023
+    g_epoch0 = unix_epoch_sec;
+    g_synced_at_epoch = unix_epoch_sec;
+    g_at0 = get_absolute_time();
+    g_synced = true;
+    return true;
+}
+
+bool het68_time_synced(void) { return g_synced; }
+
+uint32_t het68_time_epoch_sec(void) {
+    if (!g_synced) return 0;
+    int64_t us = absolute_time_diff_us(g_at0, get_absolute_time());
+    if (us < 0) us = 0;
+    return g_epoch0 + (uint32_t)(us / 1000000);
+}
+
+uint32_t het68_time_epoch_ms(void) {
+    if (!g_synced) return 0;
+    int64_t us = absolute_time_diff_us(g_at0, get_absolute_time());
+    if (us < 0) us = 0;
+    return g_epoch0 * 1000u + (uint32_t)(us / 1000);
+}
+
+uint32_t het68_time_synced_at(void) { return g_synced_at_epoch; }
+
+void het68_time_dump_uart(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("TIME synced=");
+    dbg_puts(g_synced ? "1" : "0");
+    dbg_puts(" epoch=");
+    dbg_putu32(het68_time_epoch_sec());
+    dbg_puts(" synced_at=");
+    dbg_putu32(g_synced_at_epoch);
+    dbg_putc('\n');
+    dbg_line_unlock(lock);
+}

--- a/het68_time.h
+++ b/het68_time.h
@@ -1,0 +1,16 @@
+// het68_time.h — wall-clock time synced over UART (required for DET timestamps).
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+void het68_time_init(void);
+
+// TIME SYNC <unix_epoch_seconds>
+bool het68_time_sync(uint32_t unix_epoch_sec);
+
+bool het68_time_synced(void);
+uint32_t het68_time_epoch_sec(void);   // 0 if not synced
+uint32_t het68_time_epoch_ms(void);    // 0 if not synced
+uint32_t het68_time_synced_at(void);   // epoch when SYNC was applied (0 if never)
+
+void het68_time_dump_uart(void);

--- a/main.c
+++ b/main.c
@@ -26,6 +26,9 @@
 #include "buzzer.h"
 #include "doa.h"
 #include "entity_store.h"
+#include "detection_log.h"
+#include "het68_time.h"
+#include "cli.h"
 #include "core1_launch.h"
 #include "i2s_rx.pio.h"
 #include "i2s_clk.pio.h"
@@ -708,7 +711,8 @@ static void dbg_heartbeat(uint32_t hb_count)
     {
         extern volatile uint32_t g_doa_out, g_doa_nactive, g_doa_iter;
         extern volatile uint32_t g_doa_ndrone, g_doa_nwalker, g_doa_nvehicle;
-        extern volatile uint32_t g_doa_nbird, g_doa_entity_id;
+        extern volatile uint32_t g_doa_nbird, g_doa_entity_id, g_doa_wind;
+        extern volatile float g_doa_wind_db;
         dbg_puts(" doa(out/act/iter)=");
         dbg_putu32(g_doa_out);
         dbg_putc('/');
@@ -723,10 +727,26 @@ static void dbg_heartbeat(uint32_t hb_count)
         dbg_putu32(g_doa_nbird);
         dbg_puts(" walker=");
         dbg_putu32(g_doa_nwalker);
+        dbg_puts(" wind=");
+        dbg_putu32(g_doa_wind);
+        if (g_doa_wind) {
+            dbg_puts("@");
+            // one decimal via integer tenths
+            int32_t t = (int32_t)(g_doa_wind_db * 10.0f);
+            if (t < 0) { dbg_putc('-'); t = -t; }
+            dbg_putu32((uint32_t)(t / 10));
+            dbg_putc('.');
+            dbg_putu32((uint32_t)(t % 10));
+            dbg_puts("dB");
+        }
         dbg_puts(" entity=");
         dbg_putu32(g_doa_entity_id);
-        if (entity_store_dirty()) dbg_puts(" flash=dirty");
-        if (entity_store_saving()) dbg_puts(" flash=saving");
+        dbg_puts(" det=");
+        dbg_putu32(detection_log_count());
+        if (!het68_time_synced()) dbg_puts(" time=unsynced");
+        if (entity_store_dirty() || detection_log_dirty()) dbg_puts(" flash=dirty");
+        if (entity_store_saving() || detection_log_saving()) dbg_puts(" flash=saving");
+        if (!dbg_log_enabled()) dbg_puts(" log=off");
     }
 #endif
     dbg_putc('\n');
@@ -736,6 +756,7 @@ static void dbg_heartbeat(uint32_t hb_count)
 void tud_mount_cb(void)
 {
     dbg_puts("USB mounted\n");
+    cli_on_connect();
 }
 
 void tud_umount_cb(void)
@@ -782,15 +803,21 @@ int main(void)
     dbg_puts("buzzer: PS1240 H-bridge GP6/GP7, 4kHz PN beacon\n");
 
 #if !HET68_USB_DIAG
-    // Flash-backed entity gallery (ACID dual-slot). Dump before DOA starts.
+    het68_time_init();
+    cli_init();
+
+    // Flash-backed entity gallery + detection log (ACID dual-slot each).
     entity_store_core_init();
     entity_store_init();
+    detection_log_core_init();
+    detection_log_init();
     entity_store_dump_uart();
-    dbg_puts("UART cmds: ENT LIST|EXPORT|IMPORT|END|HELP\n");
+    detection_log_list_uart();
+    cli_print_help();
 
     // Direction-of-arrival on core1 (het68_launch_core1 resets core1 after SWD flash).
     doa_start();
-    dbg_puts("DOA: drone+vehicle+bird+walker (opportunistic ACID flash)\n");
+    dbg_puts("DOA: drone+vehicle+bird+walker+wind (DET log needs TIME SYNC)\n");
 #endif
 
     // Heartbeat LED. Boards whose LED is on a wireless module (e.g. Pico W /
@@ -808,13 +835,6 @@ int main(void)
     absolute_time_t next_heartbeat = make_timeout_time_ms(2000);
     uint32_t hb_count = 0;
 
-#if !HET68_USB_DIAG
-    // UART command line buffer (entity download/upload).
-    char cmd_buf[160];
-    uint32_t cmd_len = 0;
-    bool import_mode = false;
-#endif
-
     for (;;) {
         tud_task();
 
@@ -825,49 +845,17 @@ int main(void)
         }
 
         // Opportunistic ACID flash: only when USB audio streaming is idle (alt=0).
-        entity_store_poll(dbg_last_alt == 0u);
+        // Never run both flash state machines in the same poll (one erase/page max).
+        bool usb_idle = (dbg_last_alt == 0u);
+        if (!detection_log_saving())
+            entity_store_poll(usb_idle);
+        if (!entity_store_saving())
+            detection_log_poll(usb_idle);
 
-        // Non-blocking UART command parser.
         while (dbg_rx_available()) {
             int ch = dbg_getc();
             if (ch < 0) break;
-            if (ch == '\r') continue;
-            if (ch == '\n') {
-                cmd_buf[cmd_len < sizeof(cmd_buf) ? cmd_len : (sizeof(cmd_buf) - 1u)] = '\0';
-                if (cmd_len > 0) {
-                    if (import_mode) {
-                        if (strcmp(cmd_buf, "ENT END") == 0 || strcmp(cmd_buf, "ENTBLOB END") == 0) {
-                            entity_store_import_end();
-                            import_mode = false;
-                        } else if (!entity_store_import_hex_line(cmd_buf)) {
-                            dbg_puts("ENT IMPORT ERR: bad hex line\n");
-                            import_mode = false;
-                        }
-                    } else if (strcmp(cmd_buf, "ENT LIST") == 0 || strcmp(cmd_buf, "ENT DUMP") == 0) {
-                        entity_store_dump_uart();
-                    } else if (strcmp(cmd_buf, "ENT EXPORT") == 0) {
-                        entity_store_export_uart();
-                    } else if (strcmp(cmd_buf, "ENT IMPORT") == 0) {
-                        if (entity_store_import_begin()) {
-                            import_mode = true;
-                            dbg_puts("ENT IMPORT: send ENTHEX lines, then ENT END\n");
-                        } else {
-                            dbg_puts("ENT IMPORT ERR: busy (flash save in progress)\n");
-                        }
-                    } else if (strcmp(cmd_buf, "ENT HELP") == 0 || strcmp(cmd_buf, "HELP") == 0) {
-                        dbg_puts("ENT LIST — print gallery\n");
-                        dbg_puts("ENT EXPORT — download hex blob\n");
-                        dbg_puts("ENT IMPORT — upload hex blob (ENTHEX … / ENT END)\n");
-                    } else if (strncmp(cmd_buf, "ENT", 3) == 0) {
-                        dbg_puts("ENT ?: try ENT HELP\n");
-                    }
-                }
-                cmd_len = 0;
-            } else if (cmd_len + 1u < sizeof(cmd_buf)) {
-                cmd_buf[cmd_len++] = (char)ch;
-            } else {
-                cmd_len = 0; // overflow — resync
-            }
+            cli_rx_byte(ch);
         }
 #endif
         // Audio frames are produced in tud_audio_tx_done_pre_load_cb(), driven by


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Version **1.0.6**

### Wind
- Keep existing drone **wind gate** (`DOA_WIND_RATIO`).
- Additionally report **intensity (dB)** and **steered az/el** from LF (~250 Hz) mic energies: `SRC class=wind …`.

### Detection log (separate from entity gallery)
- New `detection_log` flash region (ACID dual-slot below gallery).
- Fields: `first_seen`, `last_seen`, `occurrence`, `max_gap_ms`, az/el/intensity.
- Timestamps only after `TIME SYNC <unix>` since boot.

### UART CLI
- Help on boot / first UART byte / USB mount.
- `TIME` / `TIME SYNC`, `LOG ON|OFF`, `DET LIST|EXPORT|BACKUP|IMPORT|DEL|CLEAR`, `ENT …`.
- `DET EXPORT` → JSON Lines (`NVREVT`) for smart-NVR correlation.

### Docs
- [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md) — practical lab scenarios.

## Test plan
- [x] `./build.sh` ELF/UF2
- [ ] Scenarios A–G in `TEST_SCENARIOS_1.0.6.md`
- [ ] USB stream idle flash commit without audio stall

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

