### PR TITLE
1.1.0: BLE OpenDroneID / Remote ID scan on Wi‑Fi boards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # Build firmware on a GitHub Release whose tag is semver core (semver.org):
 #   x.y.z   or   vx.y.z
-# Uploads UF2 + ELF as release assets.
+# Uploads UF2 + ELF as release assets (pico2 + Plus 2 W when applicable).
 name: Release firmware
 
 on:
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build-and-upload:
-    name: Build pico2 firmware
+    name: Build firmware
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -28,8 +28,6 @@ jobs:
           TAG: ${{ github.event.release.tag_name }}
         run: |
           set -Eeuo pipefail
-          # Core SemVer only: MAJOR.MINOR.PATCH, optional leading "v".
-          # See https://semver.org/ — pre-release / build metadata not accepted here.
           if [[ ! "${TAG}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Release tag '${TAG}' is not x.y.z or vx.y.z (semver.org core)."
             echo "Create the release with a tag like 1.2.3 or v1.2.3."
@@ -60,15 +58,14 @@ jobs:
       - name: Fetch Pico SDK (pinned 2.2.0)
         run: ./scripts/fetch_pico_sdk.sh
 
-      - name: Build firmware
+      - name: Build pico2 firmware
         env:
           PICO_BOARD: pico2
-          # Prefer GNU host toolchain for picotool (SDK host tool), not clang-as-c++.
           CC: gcc
           CXX: g++
         run: ./build.sh
 
-      - name: Stage release artifacts
+      - name: Stage pico2 artifacts
         env:
           VERSION: ${{ steps.semver.outputs.version }}
         run: |
@@ -76,9 +73,28 @@ jobs:
           test -f build/pico_6mic_soundcard.uf2
           test -f build/pico_6mic_soundcard.elf
           mkdir -p dist
-          # One pair per release — versioned names (same bytes as local build output).
           cp -v build/pico_6mic_soundcard.uf2 "dist/het68-${VERSION}-pico2.uf2"
           cp -v build/pico_6mic_soundcard.elf "dist/het68-${VERSION}-pico2.elf"
+
+      - name: Build Pico Plus 2 W firmware (BLE Remote ID)
+        env:
+          PICO_BOARD: pimoroni_pico_plus2_w_rp2350
+          CC: gcc
+          CXX: g++
+        run: |
+          set -Eeuo pipefail
+          rm -rf build
+          ./build.sh
+
+      - name: Stage Plus 2 W artifacts
+        env:
+          VERSION: ${{ steps.semver.outputs.version }}
+        run: |
+          set -Eeuo pipefail
+          test -f build/pico_6mic_soundcard.uf2
+          test -f build/pico_6mic_soundcard.elf
+          cp -v build/pico_6mic_soundcard.uf2 "dist/het68-${VERSION}-pico-plus2-w.uf2"
+          cp -v build/pico_6mic_soundcard.elf "dist/het68-${VERSION}-pico-plus2-w.elf"
           ls -la dist/
 
       - name: Upload assets to GitHub Release
@@ -88,4 +104,6 @@ jobs:
           files: |
             dist/het68-${{ steps.semver.outputs.version }}-pico2.uf2
             dist/het68-${{ steps.semver.outputs.version }}-pico2.elf
+            dist/het68-${{ steps.semver.outputs.version }}-pico-plus2-w.uf2
+            dist/het68-${{ steps.semver.outputs.version }}-pico-plus2-w.elf
           fail_on_unmatched_files: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,13 @@ set(SRCS
     detection_log.c
     het68_time.c
     cli.c
+    remote_id.c
 )
 
 add_executable(pico_6mic_soundcard ${SRCS})
+
+# Version stamp (UART help / docs). Semver core for releases.
+add_compile_definitions(HET68_VERSION_STR=\"1.1.0\")
 
 # PIO header po add_executable
 pico_generate_pio_header(pico_6mic_soundcard ${CMAKE_CURRENT_LIST_DIR}/pio/i2s_rx.pio)
@@ -105,6 +109,29 @@ target_link_libraries(pico_6mic_soundcard
     tinyusb_device
     tinyusb_board
 )
+
+# OpenDroneID BLE scanner on CYW43 boards (Pico W / Pico Plus 2 W).
+# Relocate BTstack TLV flash bank so it does not collide with DET/ENT ACID slots
+# (last 4 sectors): BT uses sectors [-6,-5], DET [-4,-3], ENT [-2,-1].
+if (PICO_CYW43_SUPPORTED)
+    message(STATUS "het68: CYW43 board — enabling BLE OpenDroneID (HET68_BT_RID)")
+    target_compile_definitions(pico_6mic_soundcard PRIVATE
+        HET68_BT_RID=1
+        # 6 * 4096 — keep expression numeric; FLASH_SECTOR_SIZE is 4096 on RP2
+        PICO_FLASH_BANK_TOTAL_SIZE=8192
+        PICO_FLASH_BANK_STORAGE_OFFSET=\(PICO_FLASH_SIZE_BYTES-24576\)
+    )
+    target_link_libraries(pico_6mic_soundcard
+        pico_cyw43_arch_none
+        pico_btstack_ble
+        pico_btstack_cyw43
+    )
+    target_include_directories(pico_6mic_soundcard PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}  # btstack_config.h
+    )
+else()
+    target_compile_definitions(pico_6mic_soundcard PRIVATE HET68_BT_RID=0)
+endif()
 
 # core1 stack lives in SCRATCH_X (4 KiB on RP2350); default 2 KiB is enough because
 # DOA keeps large working buffers static (see s_corr in doa.c).

--- a/README.md
+++ b/README.md
@@ -177,7 +177,16 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
 
   UART **CLI** (help on boot / first byte / USB mount): `HELP`, `TIME` /
   `TIME SYNC`, `LOG ON|OFF`, `DET LIST|EXPORT|BACKUP|IMPORT|DEL|CLEAR`,
-  `ENT LIST|EXPORT|IMPORT`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
+  `ENT LIST|EXPORT|IMPORT`, `RID LIST|ON|OFF`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
+
+* **OpenDroneID / EU Direct Remote ID (v1.1.0).** On CYW43 boards
+  (`PICO_BOARD=pimoroni_pico_plus2_w_rp2350` or other Pico W variants) the
+  firmware scans BLE advertisements for service UUID `0xFFFA` and parses ASTM
+  F3411 Basic ID + Location messages (e.g. Dronetag / built-in RID). Tracks show
+  up in the heartbeat as `rid=N`, via `RID LIST`, and as DET class `remoteid`
+  after `TIME SYNC`. Non-wireless `pico2` builds compile a stub (CLI reports
+  unsupported). BTstack flash TLV is relocated so it does not overlap DET/ENT
+  ACID sectors.
 
   ```
   SRC class=wind az=180.0 el=10.0 inten=-22.5dB

--- a/btstack_config.h
+++ b/btstack_config.h
@@ -1,0 +1,42 @@
+// btstack_config.h — minimal BTstack config for OpenDroneID BLE scan (LE central).
+// Only used on CYW43 boards (Pico W / Pico Plus 2 W).
+#ifndef HET68_BTSTACK_CONFIG_H
+#define HET68_BTSTACK_CONFIG_H
+
+#define ENABLE_LE_CENTRAL
+#define ENABLE_LE_PERIPHERAL
+#define ENABLE_LOG_ERROR
+// Required by pico-sdk's hci_dump_embedded_stdout.c even if we never dump HCI.
+#define ENABLE_PRINTF_HEXDUMP
+
+#define HCI_OUTGOING_PRE_BUFFER_SIZE 4
+#define HCI_ACL_PAYLOAD_SIZE (255 + 4)
+#define HCI_ACL_CHUNK_SIZE_ALIGNMENT 4
+
+#define MAX_NR_HCI_CONNECTIONS 1
+#define MAX_NR_GATT_CLIENTS 0
+#define MAX_NR_L2CAP_CHANNELS 1
+#define MAX_NR_L2CAP_SERVICES 0
+#define MAX_NR_SM_LOOKUP_ENTRIES 1
+#define MAX_NR_WHITELIST_ENTRIES 1
+#define MAX_NR_LE_DEVICE_DB_ENTRIES 1
+
+// Limit buffers — shared CYW43 bus with (unused) Wi-Fi path.
+#define MAX_NR_CONTROLLER_ACL_BUFFERS 3
+#define MAX_NR_CONTROLLER_SCO_PACKETS 0
+#define ENABLE_HCI_CONTROLLER_TO_HOST_FLOW_CONTROL
+#define HCI_HOST_ACL_PACKET_LEN 255
+#define HCI_HOST_ACL_PACKET_NUM 2
+#define HCI_HOST_SCO_PACKET_LEN 0
+#define HCI_HOST_SCO_PACKET_NUM 0
+
+#define NVM_NUM_DEVICE_DB_ENTRIES 4
+#define NVM_NUM_LINK_KEYS 0
+#define MAX_ATT_DB_SIZE 0
+
+#define HAVE_EMBEDDED_TIME_MS
+#define HAVE_ASSERT
+
+#define HCI_RESET_RESEND_TIMEOUT_MS 1000
+
+#endif

--- a/cli.c
+++ b/cli.c
@@ -4,6 +4,7 @@
 #include "entity_store.h"
 #include "detection_log.h"
 #include "het68_time.h"
+#include "remote_id.h"
 #include <string.h>
 
 static char g_buf[192];
@@ -14,7 +15,13 @@ static bool g_help_shown;
 
 void cli_print_help(void) {
     uint32_t lock = dbg_line_lock();
-    dbg_puts("=== het68 CLI ===\n");
+    dbg_puts("=== het68 CLI ");
+#ifdef HET68_VERSION_STR
+    dbg_puts(HET68_VERSION_STR);
+#else
+    dbg_puts("?");
+#endif
+    dbg_puts(" ===\n");
     dbg_puts("HELP                 — this help\n");
     dbg_puts("TIME                 — show clock / sync status\n");
     dbg_puts("TIME SYNC <unix>     — sync wall clock (required for DET timestamps)\n");
@@ -28,6 +35,8 @@ void cli_print_help(void) {
     dbg_puts("DET CLEAR            — delete all detections\n");
     dbg_puts("ENT LIST             — entity gallery (classification templates)\n");
     dbg_puts("ENT EXPORT|IMPORT    — gallery hex blob transfer\n");
+    dbg_puts("RID LIST             — OpenDroneID BLE tracks (CYW43 boards)\n");
+    dbg_puts("RID ON | RID OFF     — enable/disable BLE Remote ID scan\n");
     dbg_puts("Note: DET timestamps only after TIME SYNC since boot.\n");
     dbg_puts("=================\n");
     dbg_line_unlock(lock);
@@ -175,8 +184,32 @@ static void handle_line(char *line) {
         return;
     }
 
+    if (strcmp(line, "RID LIST") == 0 || strcmp(line, "RID") == 0) {
+        remote_id_list_uart();
+        return;
+    }
+    if (strcmp(line, "RID ON") == 0) {
+        if (!remote_id_available()) {
+            dbg_puts("RID ERR: unsupported on this board\n");
+        } else {
+            remote_id_set_enabled(true);
+            dbg_puts("RID scan=on\n");
+        }
+        return;
+    }
+    if (strcmp(line, "RID OFF") == 0) {
+        if (!remote_id_available()) {
+            dbg_puts("RID ERR: unsupported on this board\n");
+        } else {
+            remote_id_set_enabled(false);
+            dbg_puts("RID scan=off\n");
+        }
+        return;
+    }
+
     if (strncmp(line, "DET", 3) == 0 || strncmp(line, "ENT", 3) == 0 ||
-        strncmp(line, "TIME", 4) == 0 || strncmp(line, "LOG", 3) == 0) {
+        strncmp(line, "TIME", 4) == 0 || strncmp(line, "LOG", 3) == 0 ||
+        strncmp(line, "RID", 3) == 0) {
         dbg_puts("?: unknown command — HELP\n");
     }
 }

--- a/detection_log.c
+++ b/detection_log.c
@@ -66,13 +66,14 @@ const char *det_class_name(det_class_t c) {
         case DET_BIRD:     return "bird";
         case DET_SONGBIRD: return "songbird";
         case DET_CORVID:   return "corvid";
+        case DET_REMOTEID: return "remoteid";
         default:           return "none";
     }
 }
 
 det_class_t det_class_from_name(const char *name) {
     if (!name) return DET_NONE;
-    for (int c = 1; c <= (int)DET_CORVID; c++) {
+    for (int c = 1; c <= (int)DET_REMOTEID; c++) {
         if (strcmp(name, det_class_name((det_class_t)c)) == 0)
             return (det_class_t)c;
     }

--- a/detection_log.h
+++ b/detection_log.h
@@ -23,6 +23,7 @@ typedef enum {
     DET_BIRD     = 10,
     DET_SONGBIRD = 11,
     DET_CORVID   = 12,
+    DET_REMOTEID = 13,  // OpenDroneID / EU Direct Remote ID (BLE)
 } det_class_t;
 
 typedef struct {

--- a/main.c
+++ b/main.c
@@ -24,6 +24,7 @@
 #include "tusb.h"
 #include "debug_io.h"
 #include "buzzer.h"
+#include "remote_id.h"
 #include "doa.h"
 #include "entity_store.h"
 #include "detection_log.h"
@@ -743,6 +744,8 @@ static void dbg_heartbeat(uint32_t hb_count)
         dbg_putu32(g_doa_entity_id);
         dbg_puts(" det=");
         dbg_putu32(detection_log_count());
+        dbg_puts(" rid=");
+        dbg_putu32(remote_id_active_count());
         if (!het68_time_synced()) dbg_puts(" time=unsynced");
         if (entity_store_dirty() || detection_log_dirty()) dbg_puts(" flash=dirty");
         if (entity_store_saving() || detection_log_saving()) dbg_puts(" flash=saving");
@@ -768,6 +771,13 @@ void tud_umount_cb(void)
 int main(void)
 {
     dbg_init();
+    dbg_puts("het68 ");
+#ifdef HET68_VERSION_STR
+    dbg_puts(HET68_VERSION_STR);
+#else
+    dbg_puts("?");
+#endif
+    dbg_putc('\n');
 
 #if HET68_USB_DIAG
     diag_build_lut();
@@ -818,6 +828,14 @@ int main(void)
     // Direction-of-arrival on core1 (het68_launch_core1 resets core1 after SWD flash).
     doa_start();
     dbg_puts("DOA: drone+vehicle+bird+walker+wind (DET log needs TIME SYNC)\n");
+
+    // OpenDroneID BLE scanner (no-op stub on non-CYW43 boards).
+    if (remote_id_init())
+        dbg_puts("RID: OpenDroneID BLE beacon scan enabled\n");
+    else if (remote_id_available())
+        dbg_puts("RID: init failed\n");
+    else
+        dbg_puts("RID: skipped (board has no Wi-Fi/BT)\n");
 #endif
 
     // Heartbeat LED. Boards whose LED is on a wireless module (e.g. Pico W /
@@ -857,6 +875,8 @@ int main(void)
             if (ch < 0) break;
             cli_rx_byte(ch);
         }
+
+        remote_id_poll();
 #endif
         // Audio frames are produced in tud_audio_tx_done_pre_load_cb(), driven by
         // the USB IN cadence — nothing to pump from the main loop here.

--- a/remote_id.c
+++ b/remote_id.c
@@ -1,0 +1,383 @@
+// remote_id.c — OpenDroneID BLE advertisement scanner (EU Direct Remote ID).
+//
+// Parses ASTM F3411 messages from BLE Service Data UUID 0xFFFA.
+// No malloc; updates static track table from the BTstack HCI callback.
+#include "remote_id.h"
+#include "debug_io.h"
+#include "detection_log.h"
+#include "pico/stdlib.h"
+#include <string.h>
+
+#ifndef HET68_BT_RID
+#define HET68_BT_RID 0
+#endif
+
+#if !HET68_BT_RID
+
+bool remote_id_init(void) { return false; }
+bool remote_id_available(void) { return false; }
+void remote_id_set_enabled(bool on) { (void)on; }
+bool remote_id_enabled(void) { return false; }
+void remote_id_poll(void) {}
+uint32_t remote_id_count(void) { return 0; }
+const rid_track_t *remote_id_track(uint32_t index) { (void)index; return NULL; }
+void remote_id_list_uart(void) {
+    dbg_puts("RID: unsupported on this board (needs Wi-Fi/BT CYW43)\n");
+}
+uint32_t remote_id_active_count(void) { return 0; }
+
+#else // HET68_BT_RID
+
+#include "btstack.h"
+#include "pico/cyw43_arch.h"
+#include "pico/btstack_cyw43.h"
+
+#define RID_SERVICE_UUID   0xFFFAu
+#define RID_APP_CODE       0x0Du
+#define RID_MSG_SIZE       25u
+#define RID_STALE_MS       15000u
+#define RID_LOG_MIN_MS     2000u
+
+static rid_track_t g_tracks[RID_MAX_TRACKS];
+static btstack_packet_callback_registration_t g_hci_cb;
+static volatile bool g_ready;
+static volatile bool g_enabled = true;
+static volatile bool g_scan_on;
+static uint32_t g_last_log_ms;
+
+static int32_t rd_i32_le(const uint8_t *p) {
+    return (int32_t)((uint32_t)p[0] | ((uint32_t)p[1] << 8) |
+                     ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24));
+}
+
+static int16_t rd_i16_le(const uint8_t *p) {
+    return (int16_t)((uint16_t)p[0] | ((uint16_t)p[1] << 8));
+}
+
+static rid_track_t *track_for_addr(const uint8_t addr[6], uint32_t now_ms) {
+    int free_i = -1;
+    int oldest_i = 0;
+    uint32_t oldest_ms = UINT32_MAX;
+    for (int i = 0; i < RID_MAX_TRACKS; i++) {
+        if (!g_tracks[i].used) {
+            if (free_i < 0) free_i = i;
+            continue;
+        }
+        if (memcmp(g_tracks[i].addr, addr, 6) == 0)
+            return &g_tracks[i];
+        if (g_tracks[i].last_ms < oldest_ms) {
+            oldest_ms = g_tracks[i].last_ms;
+            oldest_i = i;
+        }
+    }
+    int idx = (free_i >= 0) ? free_i : oldest_i;
+    memset(&g_tracks[idx], 0, sizeof(g_tracks[idx]));
+    g_tracks[idx].used = 1;
+    memcpy(g_tracks[idx].addr, addr, 6);
+    g_tracks[idx].heading_deg = 361;
+    g_tracks[idx].last_ms = now_ms;
+    return &g_tracks[idx];
+}
+
+static void parse_basic_id(rid_track_t *t, const uint8_t *m) {
+    t->id_type = (uint8_t)((m[1] >> 4) & 0x0Fu);
+    t->ua_type = (uint8_t)(m[1] & 0x0Fu);
+    memcpy(t->uas_id, &m[2], 20);
+    t->uas_id[20] = '\0';
+    // Trim trailing spaces / NULs already zeroed
+    for (int i = 19; i >= 0; i--) {
+        if (t->uas_id[i] == ' ' || t->uas_id[i] == '\0')
+            t->uas_id[i] = '\0';
+        else
+            break;
+    }
+    t->has_basic = 1;
+}
+
+static void parse_location(rid_track_t *t, const uint8_t *m) {
+    // ASTM F3411 Location/Vector message (type 1), simplified fields.
+    t->lat_e7 = rd_i32_le(&m[5]);
+    t->lon_e7 = rd_i32_le(&m[9]);
+    // SpeedHorizontal: byte3, units 0.25 m/s → cm/s approx
+    t->speed_cm_s = (uint16_t)((uint16_t)m[3] * 25u);
+    // Direction: byte2, 0..179 means 0..358 deg in 2° steps when Mult flag clear
+    if (m[2] <= 179u)
+        t->heading_deg = (uint16_t)(m[2] * 2u);
+    else
+        t->heading_deg = 361u;
+    // Geo altitude: bytes 15-16, encoded as (value * 0.5) - 1000 m
+    int16_t enc = rd_i16_le(&m[15]);
+    t->alt_geoid_m = (int16_t)((enc / 2) - 1000);
+    t->has_location = 1;
+}
+
+static void parse_odid_message(rid_track_t *t, const uint8_t *m) {
+    uint8_t msg_type = (uint8_t)((m[0] >> 4) & 0x0Fu);
+    uint8_t ver = (uint8_t)(m[0] & 0x0Fu);
+    if (ver > 2u) return;
+    switch (msg_type) {
+        case 0x0: parse_basic_id(t, m); break;
+        case 0x1: parse_location(t, m); break;
+        case 0xF: {
+            // Message pack: byte1 = count, then count * 25-byte messages
+            uint8_t n = m[1];
+            if (n > 9u) n = 9u;
+            const uint8_t *p = &m[2];
+            // Pack body may continue past this 25-byte page in extended adv;
+            // for legacy we only have what fits — parse first embedded msg if present.
+            if (n >= 1u && (2u + RID_MSG_SIZE) <= RID_MSG_SIZE) {
+                // Single-page pack rarely fits a full child; try offset search below.
+            }
+            (void)p;
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+static bool looks_like_odid_hdr(uint8_t b0) {
+    uint8_t t = (uint8_t)((b0 >> 4) & 0x0Fu);
+    uint8_t v = (uint8_t)(b0 & 0x0Fu);
+    if (v > 2u) return false;
+    return (t <= 5u) || (t == 0x0Fu);
+}
+
+static void ingest_service_payload(rid_track_t *t, const uint8_t *data, uint8_t len) {
+    // Possible layouts after UUID:
+    //   [AppCode=0x0D][Counter][25-byte msg…]
+    //   [Counter][25-byte msg…]
+    //   [25-byte msg…]
+    //   message pack spanning service data
+    if (len < RID_MSG_SIZE) return;
+
+    uint8_t off = 0;
+    if (len >= RID_MSG_SIZE + 2u && data[0] == RID_APP_CODE)
+        off = 2;
+    else if (len >= RID_MSG_SIZE + 1u && !looks_like_odid_hdr(data[0]) &&
+             looks_like_odid_hdr(data[1]))
+        off = 1;
+
+    // Walk remaining bytes for 25-byte aligned ODID messages
+    while ((uint8_t)(off + RID_MSG_SIZE) <= len) {
+        if (looks_like_odid_hdr(data[off])) {
+            uint8_t msg_type = (uint8_t)((data[off] >> 4) & 0x0Fu);
+            if (msg_type == 0x0Fu && (off + 2u) < len) {
+                // Message pack header in this page — parse following full messages
+                uint8_t n = data[off + 1u];
+                uint8_t p = (uint8_t)(off + 2u);
+                for (uint8_t i = 0; i < n && (uint8_t)(p + RID_MSG_SIZE) <= len; i++) {
+                    parse_odid_message(t, &data[p]);
+                    p = (uint8_t)(p + RID_MSG_SIZE);
+                }
+                off = p;
+                continue;
+            }
+            parse_odid_message(t, &data[off]);
+            off = (uint8_t)(off + RID_MSG_SIZE);
+            continue;
+        }
+        off++;
+    }
+}
+
+static void maybe_log_track(const rid_track_t *t, uint32_t now_ms) {
+    if (!dbg_log_enabled()) return;
+    if ((now_ms - g_last_log_ms) < RID_LOG_MIN_MS) return;
+    g_last_log_ms = now_ms;
+
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("RID id=");
+    dbg_puts(t->has_basic ? t->uas_id : "?");
+    dbg_puts(" rssi=");
+    if (t->rssi < 0) {
+        dbg_putc('-');
+        dbg_putu32((uint32_t)(-t->rssi));
+    } else {
+        dbg_putu32((uint32_t)t->rssi);
+    }
+    if (t->has_location) {
+        dbg_puts(" lat=");
+        // print lat/lon as integer e7 (compact, no float printf)
+        if (t->lat_e7 < 0) { dbg_putc('-'); dbg_putu32((uint32_t)(-t->lat_e7)); }
+        else dbg_putu32((uint32_t)t->lat_e7);
+        dbg_puts(" lon=");
+        if (t->lon_e7 < 0) { dbg_putc('-'); dbg_putu32((uint32_t)(-t->lon_e7)); }
+        else dbg_putu32((uint32_t)t->lon_e7);
+        dbg_puts(" alt_m=");
+        if (t->alt_geoid_m < 0) { dbg_putc('-'); dbg_putu32((uint32_t)(-t->alt_geoid_m)); }
+        else dbg_putu32((uint32_t)t->alt_geoid_m);
+    }
+    dbg_putc('\n');
+    dbg_line_unlock(lock);
+
+    // Soft DET event when we have a Basic ID (timestamps need TIME SYNC).
+    if (t->has_basic) {
+        float conf = 0.5f;
+        if (t->rssi > -60) conf = 0.9f;
+        else if (t->rssi > -80) conf = 0.7f;
+        float inten = (float)t->rssi; // dBm-ish
+        (void)detection_log_observe(DET_REMOTEID, 0u, 0.0f, 0.0f, inten, conf);
+    }
+}
+
+static void handle_adv(const uint8_t *addr, int8_t rssi,
+                       const uint8_t *adv, uint8_t adv_len) {
+    if (!g_enabled) return;
+    uint32_t now = to_ms_since_boot(get_absolute_time());
+    ad_context_t ctx;
+    bool matched = false;
+    rid_track_t *t = NULL;
+
+    for (ad_iterator_init(&ctx, adv_len, (uint8_t *)adv);
+         ad_iterator_has_more(&ctx);
+         ad_iterator_next(&ctx)) {
+        uint8_t type = ad_iterator_get_data_type(&ctx);
+        uint8_t size = ad_iterator_get_data_len(&ctx);
+        const uint8_t *data = ad_iterator_get_data(&ctx);
+        if (type != BLUETOOTH_DATA_TYPE_SERVICE_DATA) continue;
+        if (size < 2u + 1u) continue;
+        uint16_t uuid = little_endian_read_16(data, 0);
+        if (uuid != RID_SERVICE_UUID) continue;
+        if (!t) t = track_for_addr(addr, now);
+        t->rssi = rssi;
+        t->last_ms = now;
+        ingest_service_payload(t, data + 2, (uint8_t)(size - 2u));
+        matched = true;
+    }
+
+    if (matched && t)
+        maybe_log_track(t, now);
+}
+
+static void packet_handler(uint8_t packet_type, uint16_t channel,
+                           uint8_t *packet, uint16_t size) {
+    (void)channel;
+    (void)size;
+    if (packet_type != HCI_EVENT_PACKET) return;
+
+    uint8_t et = hci_event_packet_get_type(packet);
+    if (et == BTSTACK_EVENT_STATE) {
+        if (btstack_event_state_get_state(packet) == HCI_STATE_WORKING) {
+            g_ready = true;
+            if (g_enabled && !g_scan_on) {
+                // Passive scanning, ~50% duty (interval/window in 0.625 ms units).
+                gap_set_scan_parameters(0 /*passive*/, 96, 48);
+                gap_start_scan();
+                g_scan_on = true;
+                dbg_puts("RID: BLE scan started (OpenDroneID 0xFFFA)\n");
+            }
+        }
+        return;
+    }
+
+    if (et == GAP_EVENT_ADVERTISING_REPORT) {
+        bd_addr_t address;
+        gap_event_advertising_report_get_address(packet, address);
+        int8_t rssi = gap_event_advertising_report_get_rssi(packet);
+        uint8_t length = gap_event_advertising_report_get_data_length(packet);
+        const uint8_t *data = gap_event_advertising_report_get_data(packet);
+        handle_adv(address, rssi, data, length);
+        return;
+    }
+}
+
+bool remote_id_init(void) {
+    if (cyw43_arch_init()) {
+        dbg_puts("RID: cyw43_arch_init FAILED\n");
+        return false;
+    }
+
+    // BT stack is brought up inside cyw43_arch_init via btstack_cyw43_init.
+    l2cap_init();
+    sm_init();
+    g_hci_cb.callback = &packet_handler;
+    hci_add_event_handler(&g_hci_cb);
+
+    gap_set_scan_parameters(0, 96, 48);
+    hci_power_control(HCI_POWER_ON);
+    g_enabled = true;
+    dbg_puts("RID: BT OpenDroneID scanner init OK\n");
+    return true;
+}
+
+bool remote_id_available(void) { return true; }
+
+void remote_id_set_enabled(bool on) {
+    g_enabled = on;
+    if (!g_ready) return;
+    if (on && !g_scan_on) {
+        gap_start_scan();
+        g_scan_on = true;
+    } else if (!on && g_scan_on) {
+        gap_stop_scan();
+        g_scan_on = false;
+    }
+}
+
+bool remote_id_enabled(void) { return g_enabled; }
+
+void remote_id_poll(void) {
+    uint32_t now = to_ms_since_boot(get_absolute_time());
+    for (int i = 0; i < RID_MAX_TRACKS; i++) {
+        if (!g_tracks[i].used) continue;
+        if ((now - g_tracks[i].last_ms) > RID_STALE_MS)
+            g_tracks[i].used = 0;
+    }
+}
+
+uint32_t remote_id_count(void) {
+    uint32_t n = 0;
+    for (int i = 0; i < RID_MAX_TRACKS; i++)
+        if (g_tracks[i].used) n++;
+    return n;
+}
+
+uint32_t remote_id_active_count(void) { return remote_id_count(); }
+
+const rid_track_t *remote_id_track(uint32_t index) {
+    uint32_t n = 0;
+    for (int i = 0; i < RID_MAX_TRACKS; i++) {
+        if (!g_tracks[i].used) continue;
+        if (n == index) return &g_tracks[i];
+        n++;
+    }
+    return NULL;
+}
+
+void remote_id_list_uart(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("RID tracks=");
+    dbg_putu32(remote_id_count());
+    dbg_puts(" scan=");
+    dbg_puts(g_enabled ? "on" : "off");
+    dbg_puts(" ready=");
+    dbg_puts(g_ready ? "1" : "0");
+    dbg_putc('\n');
+    for (int i = 0; i < RID_MAX_TRACKS; i++) {
+        const rid_track_t *t = &g_tracks[i];
+        if (!t->used) continue;
+        dbg_puts("  ");
+        dbg_puts(t->has_basic ? t->uas_id : "(no-id)");
+        dbg_puts(" rssi=");
+        if (t->rssi < 0) { dbg_putc('-'); dbg_putu32((uint32_t)(-t->rssi)); }
+        else dbg_putu32((uint32_t)t->rssi);
+        if (t->has_location) {
+            dbg_puts(" lat=");
+            if (t->lat_e7 < 0) { dbg_putc('-'); dbg_putu32((uint32_t)(-t->lat_e7)); }
+            else dbg_putu32((uint32_t)t->lat_e7);
+            dbg_puts(" lon=");
+            if (t->lon_e7 < 0) { dbg_putc('-'); dbg_putu32((uint32_t)(-t->lon_e7)); }
+            else dbg_putu32((uint32_t)t->lon_e7);
+        }
+        dbg_puts(" mac=");
+        for (int b = 0; b < 6; b++) {
+            dbg_puthex8(t->addr[b]);
+            if (b < 5) dbg_putc(':');
+        }
+        dbg_putc('\n');
+    }
+    dbg_line_unlock(lock);
+}
+
+#endif // HET68_BT_RID

--- a/remote_id.h
+++ b/remote_id.h
@@ -1,0 +1,44 @@
+// remote_id.h — OpenDroneID / EU Direct Remote ID BLE scanner (ASTM F3411).
+//
+// Active only on CYW43 boards (Wi-Fi/BT). On pico2 builds all APIs are stubs.
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#define RID_MAX_TRACKS 8
+#define RID_UAS_ID_LEN 21  // 20 chars + NUL
+
+typedef struct {
+    uint32_t used;
+    uint8_t  addr[6];
+    int8_t   rssi;
+    char     uas_id[RID_UAS_ID_LEN];
+    uint8_t  id_type;       // ASTM ID type nibble
+    uint8_t  ua_type;       // ASTM UA type nibble
+    uint8_t  has_basic;
+    uint8_t  has_location;
+    int32_t  lat_e7;        // deg * 1e7
+    int32_t  lon_e7;
+    int16_t  alt_geoid_m;   // m, ASTM encoding decoded to metres
+    uint16_t speed_cm_s;    // horizontal, approx cm/s
+    uint16_t heading_deg;   // 0..359, 361 = unknown
+    uint32_t last_ms;
+} rid_track_t;
+
+// Returns true if BT RID is compiled in and init succeeded.
+bool remote_id_init(void);
+bool remote_id_available(void);
+
+// Enable/disable scanning (default ON after successful init).
+void remote_id_set_enabled(bool on);
+bool remote_id_enabled(void);
+
+// Age out stale tracks; safe to call from main loop (non-blocking).
+void remote_id_poll(void);
+
+uint32_t remote_id_count(void);
+const rid_track_t *remote_id_track(uint32_t index);
+void remote_id_list_uart(void);
+
+// Heartbeat counter: distinct UAS IDs / MACs seen in the last stale window.
+uint32_t remote_id_active_count(void);

--- a/scripts/fetch_pico_sdk.sh
+++ b/scripts/fetch_pico_sdk.sh
@@ -31,4 +31,8 @@ fi
 echo "pico-sdk: init tinyusb submodule"
 git -C "${SDK_DIR}" submodule update --init --depth 1 lib/tinyusb
 
+# Needed for CYW43 / BLE OpenDroneID builds (Pico W, Pico Plus 2 W).
+echo "pico-sdk: init btstack + cyw43-driver submodules"
+git -C "${SDK_DIR}" submodule update --init --depth 1 lib/btstack lib/cyw43-driver
+
 echo "pico-sdk: OK @ $(git -C "${SDK_DIR}" rev-parse HEAD) (${PICO_SDK_REF})"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds **EU Direct Remote ID / OpenDroneID** BLE scanning when the firmware is built for a CYW43 board (e.g. `PICO_BOARD=pimoroni_pico_plus2_w_rp2350`).

- Scans BLE ads for service UUID `0xFFFA` (ASTM F3411)
- Parses Basic ID + Location into up to 8 tracks
- CLI: `RID LIST`, `RID ON`, `RID OFF`
- Heartbeat: `rid=N`
- DET class `remoteid` (after `TIME SYNC`)
- `pico2` builds keep a stub (no CYW43)
- BTstack TLV flash relocated to sectors `[-6,-5]` so DET/ENT ACID slots stay intact
- Release CI builds **pico2** and **Plus 2 W** assets
- Version stamp `HET68_VERSION_STR=1.1.0`

## Test
- `./build.sh` (pico2) — OK
- `PICO_BOARD=pimoroni_pico_plus2_w_rp2350 ./build.sh` — OK (~400 kB text with BT stack)

## Hardware note
Needs Pico Plus 2 W (or other CYW43 board). No extra wiring.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

