### PR TITLE
1.1.1: sync wall clock from OpenDroneID System timestamp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(SRCS
 add_executable(pico_6mic_soundcard ${SRCS})
 
 # Version stamp (UART help / docs). Semver core for releases.
-add_compile_definitions(HET68_VERSION_STR=\"1.1.0\")
+add_compile_definitions(HET68_VERSION_STR=\"1.1.1\")
 
 # PIO header po add_executable
 pico_generate_pio_header(pico_6mic_soundcard ${CMAKE_CURRENT_LIST_DIR}/pio/i2s_rx.pio)

--- a/README.md
+++ b/README.md
@@ -179,13 +179,15 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   `TIME SYNC`, `LOG ON|OFF`, `DET LIST|EXPORT|BACKUP|IMPORT|DEL|CLEAR`,
   `ENT LIST|EXPORT|IMPORT`, `RID LIST|ON|OFF`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
 
-* **OpenDroneID / EU Direct Remote ID (v1.1.0).** On CYW43 boards
+* **OpenDroneID / EU Direct Remote ID (v1.1.0+).** On CYW43 boards
   (`PICO_BOARD=pimoroni_pico_plus2_w_rp2350` or other Pico W variants) the
   firmware scans BLE advertisements for service UUID `0xFFFA` and parses ASTM
-  F3411 Basic ID + Location messages (e.g. Dronetag / built-in RID). Tracks show
-  up in the heartbeat as `rid=N`, via `RID LIST`, and as DET class `remoteid`
-  after `TIME SYNC`. Non-wireless `pico2` builds compile a stub (CLI reports
-  unsupported). BTstack flash TLV is relocated so it does not overlap DET/ENT
+  F3411 Basic ID + Location + **System** messages (e.g. Dronetag / built-in RID).
+  Tracks show up in the heartbeat as `rid=N`, via `RID LIST`, and as DET class
+  `remoteid`. **v1.1.1:** System-message timestamp (ODID 2019 epoch → Unix)
+  auto-applies `TIME SYNC` when unsynced or when drift ≥ 2 s (rate-limited), so
+  DET timestamps work without a UART `TIME SYNC`. Non-wireless `pico2` builds
+  compile a stub. BTstack flash TLV is relocated so it does not overlap DET/ENT
   ACID sectors.
 
   ```

--- a/cli.c
+++ b/cli.c
@@ -37,7 +37,7 @@ void cli_print_help(void) {
     dbg_puts("ENT EXPORT|IMPORT    — gallery hex blob transfer\n");
     dbg_puts("RID LIST             — OpenDroneID BLE tracks (CYW43 boards)\n");
     dbg_puts("RID ON | RID OFF     — enable/disable BLE Remote ID scan\n");
-    dbg_puts("Note: DET timestamps only after TIME SYNC since boot.\n");
+    dbg_puts("Note: DET timestamps after TIME SYNC (UART or RID System msg).\n");
     dbg_puts("=================\n");
     dbg_line_unlock(lock);
 }

--- a/het68_time.c
+++ b/het68_time.c
@@ -1,6 +1,7 @@
-// het68_time.c — epoch clock anchored by UART TIME SYNC.
+// het68_time.c — epoch clock anchored by UART TIME SYNC (or RID System time).
 #include "het68_time.h"
 #include "debug_io.h"
+#include "remote_id.h"
 #include "pico/stdlib.h"
 
 static bool g_synced;
@@ -50,6 +51,12 @@ void het68_time_dump_uart(void) {
     dbg_putu32(het68_time_epoch_sec());
     dbg_puts(" synced_at=");
     dbg_putu32(g_synced_at_epoch);
+    if (remote_id_available()) {
+        dbg_puts(" rid_unix=");
+        dbg_putu32(remote_id_last_unix());
+        dbg_puts(" rid_syncs=");
+        dbg_putu32(remote_id_time_sync_count());
+    }
     dbg_putc('\n');
     dbg_line_unlock(lock);
 }

--- a/main.c
+++ b/main.c
@@ -746,7 +746,12 @@ static void dbg_heartbeat(uint32_t hb_count)
         dbg_putu32(detection_log_count());
         dbg_puts(" rid=");
         dbg_putu32(remote_id_active_count());
+        if (remote_id_time_sync_count()) {
+            dbg_puts(" rid_sync=");
+            dbg_putu32(remote_id_time_sync_count());
+        }
         if (!het68_time_synced()) dbg_puts(" time=unsynced");
+        else dbg_puts(" time=ok");
         if (entity_store_dirty() || detection_log_dirty()) dbg_puts(" flash=dirty");
         if (entity_store_saving() || detection_log_saving()) dbg_puts(" flash=saving");
         if (!dbg_log_enabled()) dbg_puts(" log=off");

--- a/remote_id.c
+++ b/remote_id.c
@@ -5,6 +5,7 @@
 #include "remote_id.h"
 #include "debug_io.h"
 #include "detection_log.h"
+#include "het68_time.h"
 #include "pico/stdlib.h"
 #include <string.h>
 
@@ -25,6 +26,8 @@ void remote_id_list_uart(void) {
     dbg_puts("RID: unsupported on this board (needs Wi-Fi/BT CYW43)\n");
 }
 uint32_t remote_id_active_count(void) { return 0; }
+uint32_t remote_id_last_unix(void) { return 0; }
+uint32_t remote_id_time_sync_count(void) { return 0; }
 
 #else // HET68_BT_RID
 
@@ -37,6 +40,11 @@ uint32_t remote_id_active_count(void) { return 0; }
 #define RID_MSG_SIZE       25u
 #define RID_STALE_MS       15000u
 #define RID_LOG_MIN_MS     2000u
+// ASTM F3411 System/Auth timestamp epoch: 2019-01-01 00:00:00 UTC
+#define RID_ODID_EPOCH_UNIX 1546300800u
+#define RID_TIME_MIN_GAP_MS 5000u
+#define RID_TIME_RESYNC_MS  30000u
+#define RID_TIME_DRIFT_SEC  2u
 
 static rid_track_t g_tracks[RID_MAX_TRACKS];
 static btstack_packet_callback_registration_t g_hci_cb;
@@ -44,10 +52,19 @@ static volatile bool g_ready;
 static volatile bool g_enabled = true;
 static volatile bool g_scan_on;
 static uint32_t g_last_log_ms;
+static volatile uint32_t g_pending_unix;
+static volatile bool g_pending_sync;
+static uint32_t g_last_unix;
+static uint32_t g_time_sync_count;
+static uint32_t g_last_rid_sync_ms;
+
+static uint32_t rd_u32_le(const uint8_t *p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) |
+           ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
 
 static int32_t rd_i32_le(const uint8_t *p) {
-    return (int32_t)((uint32_t)p[0] | ((uint32_t)p[1] << 8) |
-                     ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24));
+    return (int32_t)rd_u32_le(p);
 }
 
 static int16_t rd_i16_le(const uint8_t *p) {
@@ -111,6 +128,24 @@ static void parse_location(rid_track_t *t, const uint8_t *m) {
     t->has_location = 1;
 }
 
+// Offer wall-clock from ODID System timestamp (seconds since 2019-01-01 UTC).
+// Applied later on the main loop — never call het68_time_sync from HCI callback.
+static void offer_odid_system_time(uint32_t odid_ts_2019) {
+    if (odid_ts_2019 == 0u) return;
+    uint64_t unix64 = (uint64_t)odid_ts_2019 + (uint64_t)RID_ODID_EPOCH_UNIX;
+    if (unix64 < 1700000000ull) return;          // before het68_time floor
+    if (unix64 > 2200000000ull) return;          // reject absurd future
+    g_pending_unix = (uint32_t)unix64;
+    g_last_unix = (uint32_t)unix64;
+    g_pending_sync = true;
+}
+
+static void parse_system(rid_track_t *t, const uint8_t *m) {
+    // System message (type 4): Operator Lat/Lon + Timestamp @ bytes 20..23 (LE).
+    (void)t;
+    offer_odid_system_time(rd_u32_le(&m[20]));
+}
+
 static void parse_odid_message(rid_track_t *t, const uint8_t *m) {
     uint8_t msg_type = (uint8_t)((m[0] >> 4) & 0x0Fu);
     uint8_t ver = (uint8_t)(m[0] & 0x0Fu);
@@ -118,19 +153,10 @@ static void parse_odid_message(rid_track_t *t, const uint8_t *m) {
     switch (msg_type) {
         case 0x0: parse_basic_id(t, m); break;
         case 0x1: parse_location(t, m); break;
-        case 0xF: {
-            // Message pack: byte1 = count, then count * 25-byte messages
-            uint8_t n = m[1];
-            if (n > 9u) n = 9u;
-            const uint8_t *p = &m[2];
-            // Pack body may continue past this 25-byte page in extended adv;
-            // for legacy we only have what fits — parse first embedded msg if present.
-            if (n >= 1u && (2u + RID_MSG_SIZE) <= RID_MSG_SIZE) {
-                // Single-page pack rarely fits a full child; try offset search below.
-            }
-            (void)p;
+        case 0x4: parse_system(t, m); break;
+        case 0xF:
+            // Message pack handled by ingest walker (embedded full messages).
             break;
-        }
         default:
             break;
     }
@@ -324,6 +350,33 @@ void remote_id_poll(void) {
         if ((now - g_tracks[i].last_ms) > RID_STALE_MS)
             g_tracks[i].used = 0;
     }
+
+    // Apply pending wall-clock from System message (main loop, not HCI).
+    if (g_pending_sync) {
+        g_pending_sync = false;
+        uint32_t unix = g_pending_unix;
+        bool apply = !het68_time_synced();
+        if (!apply) {
+            uint32_t cur = het68_time_epoch_sec();
+            int32_t drift = (int32_t)unix - (int32_t)cur;
+            if (drift < 0) drift = -drift;
+            apply = ((uint32_t)drift >= RID_TIME_DRIFT_SEC) &&
+                    ((now - g_last_rid_sync_ms) >= RID_TIME_RESYNC_MS);
+        }
+        if (apply &&
+            (het68_time_synced() ? ((now - g_last_rid_sync_ms) >= RID_TIME_MIN_GAP_MS)
+                                 : true)) {
+            if (het68_time_sync(unix)) {
+                g_last_rid_sync_ms = now;
+                g_time_sync_count++;
+                uint32_t lock = dbg_line_lock();
+                dbg_puts("TIME SYNC via RID epoch=");
+                dbg_putu32(unix);
+                dbg_puts(" (OpenDroneID System)\n");
+                dbg_line_unlock(lock);
+            }
+        }
+    }
 }
 
 uint32_t remote_id_count(void) {
@@ -334,6 +387,10 @@ uint32_t remote_id_count(void) {
 }
 
 uint32_t remote_id_active_count(void) { return remote_id_count(); }
+
+uint32_t remote_id_last_unix(void) { return g_last_unix; }
+
+uint32_t remote_id_time_sync_count(void) { return g_time_sync_count; }
 
 const rid_track_t *remote_id_track(uint32_t index) {
     uint32_t n = 0;

--- a/remote_id.h
+++ b/remote_id.h
@@ -42,3 +42,8 @@ void remote_id_list_uart(void);
 
 // Heartbeat counter: distinct UAS IDs / MACs seen in the last stale window.
 uint32_t remote_id_active_count(void);
+
+// Last wall-clock offered from an OpenDroneID System message (unix epoch), or 0.
+uint32_t remote_id_last_unix(void);
+// How many successful TIME SYNCs were applied from RID System timestamps.
+uint32_t remote_id_time_sync_count(void);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Yes — OpenDroneID **System** messages carry a timestamp (seconds since 2019-01-01 UTC). This release converts it to Unix and auto-applies `TIME SYNC`.

- Parse ASTM F3411 System msg (type 4), bytes 20–23 LE
- `unix = odid_ts + 1546300800`
- Apply on main loop when unsynced, or drift ≥ 2 s (rate-limited)
- UART: `TIME SYNC via RID epoch=…`
- `TIME` dump shows `rid_unix=` / `rid_syncs=`
- Heartbeat: `rid_sync=N`, `time=ok|unsynced`

## Test
- `./build.sh` (pico2) OK
- `PICO_BOARD=pimoroni_pico_plus2_w_rp2350 ./build.sh` OK

Requires a RID beacon that broadcasts System messages (most EU DRI modules do).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

