### PR TITLE
1.1.2: TIME INFO, known-drone flash store, STATUS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,13 @@ set(SRCS
     het68_time.c
     cli.c
     remote_id.c
+    drone_store.c
 )
 
 add_executable(pico_6mic_soundcard ${SRCS})
 
 # Version stamp (UART help / docs). Semver core for releases.
-add_compile_definitions(HET68_VERSION_STR=\"1.1.1\")
+add_compile_definitions(HET68_VERSION_STR=\"1.1.2\")
 
 # PIO header po add_executable
 pico_generate_pio_header(pico_6mic_soundcard ${CMAKE_CURRENT_LIST_DIR}/pio/i2s_rx.pio)
@@ -111,8 +112,8 @@ target_link_libraries(pico_6mic_soundcard
 )
 
 # OpenDroneID BLE scanner on CYW43 boards (Pico W / Pico Plus 2 W).
-# Relocate BTstack TLV flash bank so it does not collide with DET/ENT ACID slots
-# (last 4 sectors): BT uses sectors [-6,-5], DET [-4,-3], ENT [-2,-1].
+# Flash end layout (4 KiB sectors): DRONE[-8,-7], BT[-6,-5], DET[-4,-3], ENT[-2,-1].
+# Relocate BTstack TLV so it does not collide with DRONE/DET/ENT ACID slots.
 if (PICO_CYW43_SUPPORTED)
     message(STATUS "het68: CYW43 board — enabling BLE OpenDroneID (HET68_BT_RID)")
     target_compile_definitions(pico_6mic_soundcard PRIVATE

--- a/README.md
+++ b/README.md
@@ -175,9 +175,10 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   `TIME SYNC <unix>` since boot. `DET EXPORT` emits **JSON Lines** (`NVREVT`) for
   smart-NVR event correlation.
 
-  UART **CLI** (help on boot / first byte / USB mount): `HELP`, `TIME` /
-  `TIME SYNC`, `LOG ON|OFF`, `DET LIST|EXPORT|BACKUP|IMPORT|DEL|CLEAR`,
-  `ENT LIST|EXPORT|IMPORT`, `RID LIST|ON|OFF`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
+  UART **CLI** (help on boot / first byte / USB mount): `HELP`, `STATUS`,
+  `TIME` / `TIME INFO` / `TIME SYNC`, `LOG ON|OFF`,
+  `DET LIST|EXPORT|BACKUP|IMPORT|DEL|CLEAR`, `ENT LIST|EXPORT|IMPORT`,
+  `DRONE LIST|CLEAR`, `RID LIST|ON|OFF`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
 
 * **OpenDroneID / EU Direct Remote ID (v1.1.0+).** On CYW43 boards
   (`PICO_BOARD=pimoroni_pico_plus2_w_rp2350` or other Pico W variants) the
@@ -186,9 +187,11 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   Tracks show up in the heartbeat as `rid=N`, via `RID LIST`, and as DET class
   `remoteid`. **v1.1.1:** System-message timestamp (ODID 2019 epoch → Unix)
   auto-applies `TIME SYNC` when unsynced or when drift ≥ 2 s (rate-limited), so
-  DET timestamps work without a UART `TIME SYNC`. Non-wireless `pico2` builds
-  compile a stub. BTstack flash TLV is relocated so it does not overlap DET/ENT
-  ACID sectors.
+  DET timestamps work without a UART `TIME SYNC`. **v1.1.2:** `TIME INFO`
+  reports sync **source / age / quality**; known drones (+ RID fields) persist
+  in a flash ACID store (`DRONE LIST`); `STATUS` dumps all stored data and
+  statistics (also printed on boot). Non-wireless `pico2` builds compile a
+  stub. Flash end layout: DRONE / BT TLV / DET / ENT (two sectors each).
 
   ```
   SRC class=wind az=180.0 el=10.0 inten=-22.5dB

--- a/cli.c
+++ b/cli.c
@@ -3,6 +3,7 @@
 #include "debug_io.h"
 #include "entity_store.h"
 #include "detection_log.h"
+#include "drone_store.h"
 #include "het68_time.h"
 #include "remote_id.h"
 #include <string.h>
@@ -23,7 +24,9 @@ void cli_print_help(void) {
 #endif
     dbg_puts(" ===\n");
     dbg_puts("HELP                 — this help\n");
+    dbg_puts("STATUS               — all stored data + statistics\n");
     dbg_puts("TIME                 — show clock / sync status\n");
+    dbg_puts("TIME INFO            — time source, age, quality\n");
     dbg_puts("TIME SYNC <unix>     — sync wall clock (required for DET timestamps)\n");
     dbg_puts("LOG ON | LOG OFF     — enable/disable SRC/ENTITY stdout logging\n");
     dbg_puts("LOG                  — show log status\n");
@@ -35,10 +38,63 @@ void cli_print_help(void) {
     dbg_puts("DET CLEAR            — delete all detections\n");
     dbg_puts("ENT LIST             — entity gallery (classification templates)\n");
     dbg_puts("ENT EXPORT|IMPORT    — gallery hex blob transfer\n");
+    dbg_puts("DRONE LIST           — known drones persisted in flash\n");
+    dbg_puts("DRONE CLEAR          — erase known-drone flash registry\n");
     dbg_puts("RID LIST             — OpenDroneID BLE tracks (CYW43 boards)\n");
     dbg_puts("RID ON | RID OFF     — enable/disable BLE Remote ID scan\n");
     dbg_puts("Note: DET timestamps after TIME SYNC (UART or RID System msg).\n");
     dbg_puts("=================\n");
+    dbg_line_unlock(lock);
+}
+
+void cli_print_status(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("=== STATUS ");
+#ifdef HET68_VERSION_STR
+    dbg_puts(HET68_VERSION_STR);
+#else
+    dbg_puts("?");
+#endif
+    dbg_puts(" ===\n");
+    dbg_line_unlock(lock);
+
+    het68_time_info_uart();
+
+    lock = dbg_line_lock();
+    dbg_puts("--- stats ---\n");
+    dbg_puts("DET n=");
+    dbg_putu32(detection_log_count());
+    if (detection_log_dirty()) dbg_puts(" dirty");
+    if (detection_log_saving()) dbg_puts(" saving");
+    dbg_putc('\n');
+    dbg_puts("ENT n=");
+    dbg_putu32(entity_store_count());
+    if (entity_store_dirty()) dbg_puts(" dirty");
+    if (entity_store_saving()) dbg_puts(" saving");
+    dbg_putc('\n');
+    drone_store_stats_uart();
+    dbg_puts("RID live=");
+    dbg_putu32(remote_id_active_count());
+    dbg_puts(" avail=");
+    dbg_puts(remote_id_available() ? "1" : "0");
+    dbg_puts(" scan=");
+    dbg_puts(remote_id_enabled() ? "on" : "off");
+    dbg_puts(" syncs=");
+    dbg_putu32(remote_id_time_sync_count());
+    dbg_putc('\n');
+    dbg_puts("LOG stdout=");
+    dbg_puts(dbg_log_enabled() ? "on" : "off");
+    dbg_putc('\n');
+    dbg_line_unlock(lock);
+
+    entity_store_dump_uart();
+    detection_log_list_uart();
+    drone_store_list_uart();
+    if (remote_id_available())
+        remote_id_list_uart();
+
+    lock = dbg_line_lock();
+    dbg_puts("=== end STATUS ===\n");
     dbg_line_unlock(lock);
 }
 
@@ -96,8 +152,17 @@ static void handle_line(char *line) {
         return;
     }
 
+    if (strcmp(line, "STATUS") == 0) {
+        cli_print_status();
+        return;
+    }
+
     if (strcmp(line, "TIME") == 0) {
         het68_time_dump_uart();
+        return;
+    }
+    if (strcmp(line, "TIME INFO") == 0) {
+        het68_time_info_uart();
         return;
     }
     if (strncmp(line, "TIME SYNC ", 10) == 0) {
@@ -105,6 +170,8 @@ static void handle_line(char *line) {
         if (het68_time_sync(ep)) {
             dbg_puts("TIME OK epoch=");
             dbg_putu32(het68_time_epoch_sec());
+            dbg_puts(" source=uart quality=");
+            dbg_putu32(het68_time_quality());
             dbg_putc('\n');
         } else {
             dbg_puts("TIME ERR: need unix epoch >= 1700000000\n");
@@ -184,6 +251,16 @@ static void handle_line(char *line) {
         return;
     }
 
+    if (strcmp(line, "DRONE LIST") == 0 || strcmp(line, "DRONE") == 0) {
+        drone_store_list_uart();
+        return;
+    }
+    if (strcmp(line, "DRONE CLEAR") == 0) {
+        if (drone_store_clear()) dbg_puts("DRONE CLEAR OK (pending flash)\n");
+        else dbg_puts("DRONE CLEAR ERR: busy\n");
+        return;
+    }
+
     if (strcmp(line, "RID LIST") == 0 || strcmp(line, "RID") == 0) {
         remote_id_list_uart();
         return;
@@ -209,7 +286,8 @@ static void handle_line(char *line) {
 
     if (strncmp(line, "DET", 3) == 0 || strncmp(line, "ENT", 3) == 0 ||
         strncmp(line, "TIME", 4) == 0 || strncmp(line, "LOG", 3) == 0 ||
-        strncmp(line, "RID", 3) == 0) {
+        strncmp(line, "RID", 3) == 0 || strncmp(line, "DRONE", 5) == 0 ||
+        strncmp(line, "STATUS", 6) == 0) {
         dbg_puts("?: unknown command — HELP\n");
     }
 }

--- a/cli.h
+++ b/cli.h
@@ -1,9 +1,12 @@
-// cli.h — simple UART CLI (help, time, log, DET, ENT).
+// cli.h — simple UART CLI (help, time, status, DET, ENT, RID, drones).
 #pragma once
 #include <stdbool.h>
 
 void cli_init(void);
 void cli_print_help(void);
+
+// Aggregated dump: time source/quality, DET/ENT/drone flash stats + contents.
+void cli_print_status(void);
 
 // Feed one received byte (non-blocking). Handles line assembly + commands.
 void cli_rx_byte(int ch);

--- a/drone_store.c
+++ b/drone_store.c
@@ -1,0 +1,407 @@
+// drone_store.c — RAM-first known-drone registry with opportunistic ACID flash.
+//
+// Flash layout (below BTstack TLV / DET / ENT):
+//   slot0 = PICO_FLASH_SIZE_BYTES - 8*FLASH_SECTOR_SIZE
+//   slot1 = PICO_FLASH_SIZE_BYTES - 7*FLASH_SECTOR_SIZE
+// Full layout end→start: ENT[-2,-1], DET[-4,-3], BT[-6,-5], DRONE[-8,-7].
+#include "drone_store.h"
+#include "debug_io.h"
+#include "het68_time.h"
+#include "hardware/flash.h"
+#include "hardware/sync.h"
+#include "pico/flash.h"
+#include "pico/stdlib.h"
+#include <string.h>
+
+#define DRONE_MAGIC   0x44383648u  /* 'H68D' LE */
+#define DRONE_VERSION 1u
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#error "PICO_FLASH_SIZE_BYTES must be defined by the board"
+#endif
+
+#define DRONE_SLOT0_OFF  (PICO_FLASH_SIZE_BYTES - 8u * FLASH_SECTOR_SIZE)
+#define DRONE_SLOT1_OFF  (PICO_FLASH_SIZE_BYTES - 7u * FLASH_SECTOR_SIZE)
+
+_Static_assert(sizeof(drone_blob_t) <= FLASH_SECTOR_SIZE,
+               "drone_blob_t must fit in one flash sector");
+
+#define DRONE_FLAG_BASIC    0x01u
+#define DRONE_FLAG_LOCATION 0x02u
+
+static drone_slot_t g_slots[DRONE_STORE_MAX];
+static uint32_t g_next_id = 1;
+static uint32_t g_count = 0;
+static uint32_t g_seq = 0;
+static uint32_t g_active_slot = 0;
+static volatile bool g_dirty = false;
+
+typedef enum {
+    SAVE_IDLE = 0,
+    SAVE_ERASE,
+    SAVE_PROG
+} save_phase_t;
+
+static save_phase_t g_phase = SAVE_IDLE;
+static uint32_t g_save_slot = 0;
+static uint32_t g_prog_off = 0;
+static uint8_t g_stage[FLASH_SECTOR_SIZE];
+
+static void put_i32(int32_t v) {
+    if (v < 0) {
+        dbg_putc('-');
+        dbg_putu32((uint32_t)(-v));
+    } else {
+        dbg_putu32((uint32_t)v);
+    }
+}
+
+static void put_mac(const uint8_t addr[6]) {
+    for (int b = 0; b < 6; b++) {
+        dbg_puthex8(addr[b]);
+        if (b < 5) dbg_putc(':');
+    }
+}
+
+uint8_t drone_rssi_quality(int8_t rssi) {
+    // Map typical BLE RSSI: -40 dBm → 100, -90 dBm → 20, clamp.
+    int q = 100 + ((int)rssi + 40) * 2; // -40→100, -90→0 before floor
+    if (q > 100) q = 100;
+    if (q < 20) q = 20;
+    if (rssi < -95) q = 10;
+    return (uint8_t)q;
+}
+
+static uint32_t crc32_update(uint32_t crc, const uint8_t *data, size_t len) {
+    crc = ~crc;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; b++)
+            crc = (crc & 1u) ? ((crc >> 1) ^ 0xEDB88320u) : (crc >> 1);
+    }
+    return ~crc;
+}
+
+uint32_t drone_blob_crc(const drone_blob_t *b) {
+    drone_blob_t tmp = *b;
+    tmp.crc = 0;
+    return crc32_update(0, (const uint8_t *)&tmp, sizeof(tmp));
+}
+
+static void recount(void) {
+    uint32_t n = 0;
+    for (uint32_t i = 0; i < DRONE_STORE_MAX; i++)
+        if (g_slots[i].used) n++;
+    g_count = n;
+}
+
+static bool slot_valid(const drone_blob_t *b) {
+    if (b->magic != DRONE_MAGIC) return false;
+    if (b->version != DRONE_VERSION) return false;
+    if (b->count > DRONE_STORE_MAX) return false;
+    return drone_blob_crc(b) == b->crc;
+}
+
+static void load_from_flash(void) {
+    const drone_blob_t *s0 = (const drone_blob_t *)(XIP_BASE + DRONE_SLOT0_OFF);
+    const drone_blob_t *s1 = (const drone_blob_t *)(XIP_BASE + DRONE_SLOT1_OFF);
+    memset(g_slots, 0, sizeof(g_slots));
+    g_next_id = 1;
+    g_count = 0;
+    g_seq = 0;
+    g_active_slot = 0;
+
+    bool v0 = slot_valid(s0);
+    bool v1 = slot_valid(s1);
+    const drone_blob_t *best = NULL;
+    if (v0 && v1) {
+        best = (s1->seq >= s0->seq) ? s1 : s0;
+        g_active_slot = (best == s1) ? 1u : 0u;
+    } else if (v0) {
+        best = s0;
+        g_active_slot = 0;
+    } else if (v1) {
+        best = s1;
+        g_active_slot = 1;
+    }
+    if (!best) return;
+
+    memcpy(g_slots, best->slots, sizeof(g_slots));
+    g_next_id = best->next_id ? best->next_id : 1;
+    g_seq = best->seq;
+    recount();
+}
+
+static void build_stage_blob(void) {
+    for (uint32_t i = 0; i < FLASH_SECTOR_SIZE; i++) g_stage[i] = 0xFFu;
+    drone_blob_t *b = (drone_blob_t *)g_stage;
+    memset(b, 0, sizeof(*b));
+    b->magic = DRONE_MAGIC;
+    b->version = DRONE_VERSION;
+    b->seq = g_seq + 1u;
+    b->next_id = g_next_id;
+    recount();
+    b->count = g_count;
+    memcpy(b->slots, g_slots, sizeof(g_slots));
+    b->crc = drone_blob_crc(b);
+}
+
+typedef struct { uint32_t off; uint32_t len; } flash_op_t;
+
+static void __not_in_flash_func(flash_erase_cb)(void *param) {
+    flash_op_t *op = (flash_op_t *)param;
+    flash_range_erase(op->off, FLASH_SECTOR_SIZE);
+}
+
+typedef struct {
+    uint32_t flash_off;
+    uint32_t stage_off;
+    uint32_t len;
+} flash_prog_t;
+
+static void __not_in_flash_func(flash_prog_page_cb)(void *param) {
+    flash_prog_t *op = (flash_prog_t *)param;
+    flash_range_program(op->flash_off, &g_stage[op->stage_off], op->len);
+}
+
+void drone_store_core_init(void) {
+    // flash_safe_execute_core_init is shared; entity_store already calls it.
+}
+
+void drone_store_init(void) {
+    load_from_flash();
+    g_dirty = false;
+    g_phase = SAVE_IDLE;
+}
+
+bool drone_store_dirty(void) { return g_dirty; }
+bool drone_store_saving(void) { return g_phase != SAVE_IDLE; }
+uint32_t drone_store_count(void) { return g_count; }
+uint32_t drone_store_seq(void) { return g_seq; }
+
+const drone_slot_t *drone_store_slot(uint32_t index) {
+    if (index >= DRONE_STORE_MAX) return NULL;
+    if (!g_slots[index].used) return NULL;
+    return &g_slots[index];
+}
+
+static int find_by_addr(const uint8_t addr[6]) {
+    for (uint32_t i = 0; i < DRONE_STORE_MAX; i++) {
+        if (!g_slots[i].used) continue;
+        if (memcmp(g_slots[i].addr, addr, 6) == 0) return (int)i;
+    }
+    return -1;
+}
+
+static int find_by_uas(const char *uas_id) {
+    if (!uas_id || !uas_id[0]) return -1;
+    for (uint32_t i = 0; i < DRONE_STORE_MAX; i++) {
+        if (!g_slots[i].used) continue;
+        if (g_slots[i].uas_id[0] == '\0') continue;
+        if (strncmp(g_slots[i].uas_id, uas_id, DRONE_UAS_ID_LEN) == 0)
+            return (int)i;
+    }
+    return -1;
+}
+
+static int alloc_slot(void) {
+    int free_i = -1;
+    int oldest_i = 0;
+    uint32_t oldest_last = UINT32_MAX;
+    uint32_t oldest_hits = UINT32_MAX;
+    for (uint32_t i = 0; i < DRONE_STORE_MAX; i++) {
+        if (!g_slots[i].used) {
+            if (free_i < 0) free_i = (int)i;
+            continue;
+        }
+        uint32_t last = g_slots[i].last_seen ? g_slots[i].last_seen : 0;
+        if (last < oldest_last ||
+            (last == oldest_last && g_slots[i].hits < oldest_hits)) {
+            oldest_last = last;
+            oldest_hits = g_slots[i].hits;
+            oldest_i = (int)i;
+        }
+    }
+    return (free_i >= 0) ? free_i : oldest_i;
+}
+
+void drone_store_observe(const uint8_t addr[6], int8_t rssi,
+                         const char *uas_id, uint8_t id_type, uint8_t ua_type,
+                         bool has_basic, bool has_location,
+                         int32_t lat_e7, int32_t lon_e7, int16_t alt_geoid_m,
+                         uint16_t speed_cm_s, uint16_t heading_deg,
+                         bool time_offer) {
+    if (!addr) return;
+
+    int idx = find_by_addr(addr);
+    if (idx < 0 && has_basic && uas_id && uas_id[0])
+        idx = find_by_uas(uas_id);
+
+    bool is_new = false;
+    if (idx < 0) {
+        idx = alloc_slot();
+        memset(&g_slots[idx], 0, sizeof(g_slots[idx]));
+        g_slots[idx].used = 1;
+        memcpy(g_slots[idx].addr, addr, 6);
+        g_slots[idx].heading_deg = 361;
+        is_new = true;
+        g_next_id++;
+        if (g_next_id == 0) g_next_id = 1;
+    }
+
+    drone_slot_t *s = &g_slots[idx];
+    memcpy(s->addr, addr, 6);
+    s->rssi = rssi;
+    s->quality = drone_rssi_quality(rssi);
+    if (has_basic && uas_id) {
+        strncpy(s->uas_id, uas_id, DRONE_UAS_ID_LEN - 1);
+        s->uas_id[DRONE_UAS_ID_LEN - 1] = '\0';
+        s->id_type = id_type;
+        s->ua_type = ua_type;
+        s->flags |= DRONE_FLAG_BASIC;
+    }
+    if (has_location) {
+        s->lat_e7 = lat_e7;
+        s->lon_e7 = lon_e7;
+        s->alt_geoid_m = alt_geoid_m;
+        s->speed_cm_s = speed_cm_s;
+        s->heading_deg = heading_deg;
+        s->flags |= DRONE_FLAG_LOCATION;
+    }
+    if (time_offer) s->time_offers++;
+
+    s->hits++;
+    if (het68_time_synced()) {
+        uint32_t now = het68_time_epoch_sec();
+        if (!s->first_seen) s->first_seen = now;
+        s->last_seen = now;
+    }
+
+    recount();
+    if (is_new || time_offer || has_location || (s->hits % 8u) == 0u)
+        g_dirty = true;
+}
+
+void drone_store_poll(bool usb_audio_idle) {
+    if (!usb_audio_idle) return;
+
+    if (g_phase == SAVE_IDLE) {
+        if (!g_dirty) return;
+        build_stage_blob();
+        g_save_slot = 1u - g_active_slot;
+        g_prog_off = 0;
+        g_phase = SAVE_ERASE;
+    }
+
+    if (g_phase == SAVE_ERASE) {
+        flash_op_t op = {
+            .off = (g_save_slot == 0u) ? DRONE_SLOT0_OFF : DRONE_SLOT1_OFF,
+            .len = FLASH_SECTOR_SIZE
+        };
+        int rc = flash_safe_execute(flash_erase_cb, &op, 200);
+        if (rc != PICO_OK) return;
+        g_phase = SAVE_PROG;
+        g_prog_off = 0;
+        return;
+    }
+
+    if (g_phase == SAVE_PROG) {
+        uint32_t base = (g_save_slot == 0u) ? DRONE_SLOT0_OFF : DRONE_SLOT1_OFF;
+        uint32_t need = (sizeof(drone_blob_t) + FLASH_PAGE_SIZE - 1u) &
+                        ~(FLASH_PAGE_SIZE - 1u);
+        if (g_prog_off >= need) {
+            drone_blob_t *b = (drone_blob_t *)g_stage;
+            g_seq = b->seq;
+            g_active_slot = g_save_slot;
+            g_dirty = false;
+            g_phase = SAVE_IDLE;
+            uint32_t lock = dbg_line_lock();
+            dbg_puts("FLASH: DRONE ACID commit seq=");
+            dbg_putu32(g_seq);
+            dbg_puts(" slot=");
+            dbg_putu32(g_active_slot);
+            dbg_puts(" n=");
+            dbg_putu32(g_count);
+            dbg_putc('\n');
+            dbg_line_unlock(lock);
+            return;
+        }
+        flash_prog_t op = {
+            .flash_off = base + g_prog_off,
+            .stage_off = g_prog_off,
+            .len = FLASH_PAGE_SIZE
+        };
+        int rc = flash_safe_execute(flash_prog_page_cb, &op, 200);
+        if (rc != PICO_OK) return;
+        g_prog_off += FLASH_PAGE_SIZE;
+    }
+}
+
+static void dump_one(const drone_slot_t *s) {
+    dbg_puts("DRONE id=");
+    // synthetic stable-ish id: first 3 MAC bytes + hits not needed; use index via uas
+    dbg_puts(s->uas_id[0] ? s->uas_id : "(no-id)");
+    dbg_puts(" mac=");
+    put_mac(s->addr);
+    dbg_puts(" rssi=");
+    put_i32(s->rssi);
+    dbg_puts(" q=");
+    dbg_putu32(s->quality);
+    dbg_puts(" hits=");
+    dbg_putu32(s->hits);
+    dbg_puts(" time_offers=");
+    dbg_putu32(s->time_offers);
+    if (s->flags & DRONE_FLAG_LOCATION) {
+        dbg_puts(" lat=");
+        put_i32(s->lat_e7);
+        dbg_puts(" lon=");
+        put_i32(s->lon_e7);
+        dbg_puts(" alt_m=");
+        put_i32(s->alt_geoid_m);
+    }
+    if (s->first_seen || s->last_seen) {
+        dbg_puts(" first=");
+        dbg_putu32(s->first_seen);
+        dbg_puts(" last=");
+        dbg_putu32(s->last_seen);
+    }
+    dbg_puts(" ua_type=");
+    dbg_putu32(s->ua_type);
+    dbg_putc('\n');
+}
+
+void drone_store_stats_uart(void) {
+    dbg_puts("DRONE store n=");
+    dbg_putu32(g_count);
+    dbg_puts(" seq=");
+    dbg_putu32(g_seq);
+    dbg_puts(" flash_slot=");
+    dbg_putu32(g_active_slot);
+    if (g_dirty) dbg_puts(" dirty");
+    if (g_phase != SAVE_IDLE) dbg_puts(" saving");
+    dbg_putc('\n');
+}
+
+void drone_store_list_uart(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("=== known drones (flash");
+    if (g_dirty) dbg_puts("+dirty");
+    dbg_puts(") ===\n");
+    drone_store_stats_uart();
+    if (g_count == 0) dbg_puts("(empty)\n");
+    for (uint32_t i = 0; i < DRONE_STORE_MAX; i++) {
+        if (!g_slots[i].used) continue;
+        dump_one(&g_slots[i]);
+    }
+    dbg_puts("=== end known drones ===\n");
+    dbg_line_unlock(lock);
+}
+
+bool drone_store_clear(void) {
+    if (g_phase != SAVE_IDLE) return false;
+    memset(g_slots, 0, sizeof(g_slots));
+    g_count = 0;
+    g_next_id = 1;
+    g_dirty = true;
+    return true;
+}

--- a/drone_store.h
+++ b/drone_store.h
@@ -1,0 +1,70 @@
+// drone_store.h — flash-backed registry of known OpenDroneID drones.
+//
+// Flash: ACID dual-slot in sectors [-8,-7] (below BTstack TLV / DET / ENT).
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#define DRONE_STORE_MAX   16
+#define DRONE_UAS_ID_LEN  21  // 20 chars + NUL
+
+typedef struct {
+    uint32_t used;
+    uint8_t  addr[6];
+    int8_t   rssi;
+    uint8_t  id_type;
+    uint8_t  ua_type;
+    uint8_t  flags;          // bit0 has_basic, bit1 has_location
+    uint8_t  quality;        // last RSSI-derived quality 0..100
+    char     uas_id[DRONE_UAS_ID_LEN];
+    uint8_t  _pad0;
+    int32_t  lat_e7;
+    int32_t  lon_e7;
+    int16_t  alt_geoid_m;
+    uint16_t speed_cm_s;
+    uint16_t heading_deg;
+    uint16_t _pad1;
+    uint32_t first_seen;     // unix epoch (0 if never synced when seen)
+    uint32_t last_seen;      // unix epoch
+    uint32_t hits;
+    uint32_t time_offers;    // System messages that offered wall-clock
+} drone_slot_t;
+
+typedef struct {
+    uint32_t magic;
+    uint32_t version;
+    uint32_t seq;
+    uint32_t next_id;
+    uint32_t count;
+    uint32_t crc;
+    uint32_t reserved[2];
+    drone_slot_t slots[DRONE_STORE_MAX];
+} drone_blob_t;
+
+void drone_store_core_init(void);
+void drone_store_init(void);
+void drone_store_poll(bool usb_audio_idle);
+
+bool drone_store_dirty(void);
+bool drone_store_saving(void);
+
+uint32_t drone_store_count(void);
+uint32_t drone_store_seq(void);
+const drone_slot_t *drone_store_slot(uint32_t index);
+
+// Upsert by BLE MAC (preferred) or UAS ID. RAM only — flash via poll().
+void drone_store_observe(const uint8_t addr[6], int8_t rssi,
+                         const char *uas_id, uint8_t id_type, uint8_t ua_type,
+                         bool has_basic, bool has_location,
+                         int32_t lat_e7, int32_t lon_e7, int16_t alt_geoid_m,
+                         uint16_t speed_cm_s, uint16_t heading_deg,
+                         bool time_offer);
+
+void drone_store_list_uart(void);
+void drone_store_stats_uart(void);
+
+bool drone_store_clear(void);
+uint32_t drone_blob_crc(const drone_blob_t *b);
+
+// Map RSSI (dBm) → quality 0..100 for time / drone metadata.
+uint8_t drone_rssi_quality(int8_t rssi);

--- a/het68_time.c
+++ b/het68_time.c
@@ -1,4 +1,4 @@
-// het68_time.c — epoch clock anchored by UART TIME SYNC (or RID System time).
+// het68_time.c — epoch clock anchored by UART TIME SYNC or RID System time.
 #include "het68_time.h"
 #include "debug_io.h"
 #include "remote_id.h"
@@ -8,21 +8,34 @@ static bool g_synced;
 static uint32_t g_epoch0;           // unix seconds at sync instant
 static absolute_time_t g_at0;       // pico time at sync instant
 static uint32_t g_synced_at_epoch;  // copy of g_epoch0 for status
+static het68_time_src_t g_source;
+static uint8_t g_quality_base;
 
 void het68_time_init(void) {
     g_synced = false;
     g_epoch0 = 0;
     g_synced_at_epoch = 0;
+    g_source = HET68_TIME_SRC_NONE;
+    g_quality_base = 0;
     g_at0 = get_absolute_time();
 }
 
-bool het68_time_sync(uint32_t unix_epoch_sec) {
+bool het68_time_sync_from(uint32_t unix_epoch_sec, het68_time_src_t src,
+                          uint8_t quality) {
     if (unix_epoch_sec < 1700000000u) return false; // reject nonsense / year < 2023
+    if (src == HET68_TIME_SRC_NONE) return false;
+    if (quality > 100u) quality = 100u;
     g_epoch0 = unix_epoch_sec;
     g_synced_at_epoch = unix_epoch_sec;
     g_at0 = get_absolute_time();
     g_synced = true;
+    g_source = src;
+    g_quality_base = quality;
     return true;
+}
+
+bool het68_time_sync(uint32_t unix_epoch_sec) {
+    return het68_time_sync_from(unix_epoch_sec, HET68_TIME_SRC_UART, 100u);
 }
 
 bool het68_time_synced(void) { return g_synced; }
@@ -43,10 +56,73 @@ uint32_t het68_time_epoch_ms(void) {
 
 uint32_t het68_time_synced_at(void) { return g_synced_at_epoch; }
 
+het68_time_src_t het68_time_source(void) {
+    return g_synced ? g_source : HET68_TIME_SRC_NONE;
+}
+
+const char *het68_time_source_name(het68_time_src_t src) {
+    switch (src) {
+        case HET68_TIME_SRC_UART: return "uart";
+        case HET68_TIME_SRC_RID:  return "rid";
+        default:                  return "none";
+    }
+}
+
+uint32_t het68_time_age_sec(void) {
+    if (!g_synced) return 0;
+    int64_t us = absolute_time_diff_us(g_at0, get_absolute_time());
+    if (us < 0) us = 0;
+    return (uint32_t)(us / 1000000);
+}
+
+uint8_t het68_time_quality_base(void) {
+    return g_synced ? g_quality_base : 0;
+}
+
+uint8_t het68_time_quality(void) {
+    if (!g_synced) return 0;
+    uint32_t age = het68_time_age_sec();
+    uint32_t decay = age / 60u; // ~1 point per minute
+    if (decay >= (uint32_t)g_quality_base) return 1u;
+    return (uint8_t)(g_quality_base - (uint8_t)decay);
+}
+
 void het68_time_dump_uart(void) {
     uint32_t lock = dbg_line_lock();
     dbg_puts("TIME synced=");
     dbg_puts(g_synced ? "1" : "0");
+    dbg_puts(" source=");
+    dbg_puts(het68_time_source_name(het68_time_source()));
+    dbg_puts(" epoch=");
+    dbg_putu32(het68_time_epoch_sec());
+    dbg_puts(" synced_at=");
+    dbg_putu32(g_synced_at_epoch);
+    dbg_puts(" age_s=");
+    dbg_putu32(het68_time_age_sec());
+    dbg_puts(" quality=");
+    dbg_putu32(het68_time_quality());
+    if (remote_id_available()) {
+        dbg_puts(" rid_unix=");
+        dbg_putu32(remote_id_last_unix());
+        dbg_puts(" rid_syncs=");
+        dbg_putu32(remote_id_time_sync_count());
+    }
+    dbg_putc('\n');
+    dbg_line_unlock(lock);
+}
+
+void het68_time_info_uart(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("TIME INFO synced=");
+    dbg_puts(g_synced ? "1" : "0");
+    dbg_puts(" source=");
+    dbg_puts(het68_time_source_name(het68_time_source()));
+    dbg_puts(" age_s=");
+    dbg_putu32(het68_time_age_sec());
+    dbg_puts(" quality=");
+    dbg_putu32(het68_time_quality());
+    dbg_puts(" quality_base=");
+    dbg_putu32(het68_time_quality_base());
     dbg_puts(" epoch=");
     dbg_putu32(het68_time_epoch_sec());
     dbg_puts(" synced_at=");

--- a/het68_time.h
+++ b/het68_time.h
@@ -1,16 +1,39 @@
-// het68_time.h — wall-clock time synced over UART (required for DET timestamps).
+// het68_time.h — wall-clock time synced over UART or OpenDroneID RID.
 #pragma once
 #include <stdint.h>
 #include <stdbool.h>
 
+typedef enum {
+    HET68_TIME_SRC_NONE = 0,
+    HET68_TIME_SRC_UART = 1,
+    HET68_TIME_SRC_RID  = 2,
+} het68_time_src_t;
+
 void het68_time_init(void);
 
-// TIME SYNC <unix_epoch_seconds>
+// TIME SYNC <unix_epoch_seconds> — treated as UART source, quality 100.
 bool het68_time_sync(uint32_t unix_epoch_sec);
+
+// Sync with explicit source + base quality (0..100).
+bool het68_time_sync_from(uint32_t unix_epoch_sec, het68_time_src_t src,
+                          uint8_t quality);
 
 bool het68_time_synced(void);
 uint32_t het68_time_epoch_sec(void);   // 0 if not synced
 uint32_t het68_time_epoch_ms(void);    // 0 if not synced
 uint32_t het68_time_synced_at(void);   // epoch when SYNC was applied (0 if never)
 
-void het68_time_dump_uart(void);
+het68_time_src_t het68_time_source(void);
+const char *het68_time_source_name(het68_time_src_t src);
+
+// Seconds since last successful sync (0 if never synced).
+uint32_t het68_time_age_sec(void);
+
+// Effective quality 0..100: base quality decayed by age (~1 point / 60 s).
+uint8_t het68_time_quality(void);
+
+// Base quality from the last sync (before age decay).
+uint8_t het68_time_quality_base(void);
+
+void het68_time_dump_uart(void);       // compact TIME line
+void het68_time_info_uart(void);       // TIME INFO: source / age / quality

--- a/main.c
+++ b/main.c
@@ -29,6 +29,7 @@
 #include "entity_store.h"
 #include "detection_log.h"
 #include "het68_time.h"
+#include "drone_store.h"
 #include "cli.h"
 #include "core1_launch.h"
 #include "i2s_rx.pio.h"
@@ -752,8 +753,10 @@ static void dbg_heartbeat(uint32_t hb_count)
         }
         if (!het68_time_synced()) dbg_puts(" time=unsynced");
         else dbg_puts(" time=ok");
-        if (entity_store_dirty() || detection_log_dirty()) dbg_puts(" flash=dirty");
-        if (entity_store_saving() || detection_log_saving()) dbg_puts(" flash=saving");
+        if (entity_store_dirty() || detection_log_dirty() || drone_store_dirty())
+            dbg_puts(" flash=dirty");
+        if (entity_store_saving() || detection_log_saving() || drone_store_saving())
+            dbg_puts(" flash=saving");
         if (!dbg_log_enabled()) dbg_puts(" log=off");
     }
 #endif
@@ -821,14 +824,13 @@ int main(void)
     het68_time_init();
     cli_init();
 
-    // Flash-backed entity gallery + detection log (ACID dual-slot each).
+    // Flash-backed entity gallery + detection log + known drones (ACID dual-slot each).
     entity_store_core_init();
     entity_store_init();
     detection_log_core_init();
     detection_log_init();
-    entity_store_dump_uart();
-    detection_log_list_uart();
-    cli_print_help();
+    drone_store_core_init();
+    drone_store_init();
 
     // Direction-of-arrival on core1 (het68_launch_core1 resets core1 after SWD flash).
     doa_start();
@@ -841,6 +843,10 @@ int main(void)
         dbg_puts("RID: init failed\n");
     else
         dbg_puts("RID: skipped (board has no Wi-Fi/BT)\n");
+
+    // Boot dump: all persisted data + statistics (same as UART STATUS).
+    cli_print_status();
+    cli_print_help();
 #endif
 
     // Heartbeat LED. Boards whose LED is on a wireless module (e.g. Pico W /
@@ -868,12 +874,14 @@ int main(void)
         }
 
         // Opportunistic ACID flash: only when USB audio streaming is idle (alt=0).
-        // Never run both flash state machines in the same poll (one erase/page max).
+        // At most one flash store advances per poll (one erase/page max).
         bool usb_idle = (dbg_last_alt == 0u);
-        if (!detection_log_saving())
+        if (!detection_log_saving() && !drone_store_saving())
             entity_store_poll(usb_idle);
-        if (!entity_store_saving())
+        if (!entity_store_saving() && !drone_store_saving())
             detection_log_poll(usb_idle);
+        if (!entity_store_saving() && !detection_log_saving())
+            drone_store_poll(usb_idle);
 
         while (dbg_rx_available()) {
             int ch = dbg_getc();

--- a/remote_id.c
+++ b/remote_id.c
@@ -5,6 +5,7 @@
 #include "remote_id.h"
 #include "debug_io.h"
 #include "detection_log.h"
+#include "drone_store.h"
 #include "het68_time.h"
 #include "pico/stdlib.h"
 #include <string.h>
@@ -54,6 +55,7 @@ static volatile bool g_scan_on;
 static uint32_t g_last_log_ms;
 static volatile uint32_t g_pending_unix;
 static volatile bool g_pending_sync;
+static volatile int8_t g_pending_rssi;
 static uint32_t g_last_unix;
 static uint32_t g_time_sync_count;
 static uint32_t g_last_rid_sync_ms;
@@ -130,20 +132,21 @@ static void parse_location(rid_track_t *t, const uint8_t *m) {
 
 // Offer wall-clock from ODID System timestamp (seconds since 2019-01-01 UTC).
 // Applied later on the main loop — never call het68_time_sync from HCI callback.
-static void offer_odid_system_time(uint32_t odid_ts_2019) {
+static void offer_odid_system_time(uint32_t odid_ts_2019, int8_t rssi) {
     if (odid_ts_2019 == 0u) return;
     uint64_t unix64 = (uint64_t)odid_ts_2019 + (uint64_t)RID_ODID_EPOCH_UNIX;
     if (unix64 < 1700000000ull) return;          // before het68_time floor
     if (unix64 > 2200000000ull) return;          // reject absurd future
     g_pending_unix = (uint32_t)unix64;
     g_last_unix = (uint32_t)unix64;
+    g_pending_rssi = rssi;
     g_pending_sync = true;
 }
 
 static void parse_system(rid_track_t *t, const uint8_t *m) {
     // System message (type 4): Operator Lat/Lon + Timestamp @ bytes 20..23 (LE).
-    (void)t;
-    offer_odid_system_time(rd_u32_le(&m[20]));
+    t->sys_pending = 1;
+    offer_odid_system_time(rd_u32_le(&m[20]), t->rssi);
 }
 
 static void parse_odid_message(rid_track_t *t, const uint8_t *m) {
@@ -347,14 +350,33 @@ void remote_id_poll(void) {
     uint32_t now = to_ms_since_boot(get_absolute_time());
     for (int i = 0; i < RID_MAX_TRACKS; i++) {
         if (!g_tracks[i].used) continue;
-        if ((now - g_tracks[i].last_ms) > RID_STALE_MS)
+        if ((now - g_tracks[i].last_ms) > RID_STALE_MS) {
             g_tracks[i].used = 0;
+            continue;
+        }
+
+        // Persist known drones when the live track updates (not every poll).
+        rid_track_t *t = &g_tracks[i];
+        bool time_offer = t->sys_pending != 0;
+        t->sys_pending = 0;
+        if ((t->has_basic || t->has_location) &&
+            (time_offer || t->last_ms != t->flash_ms)) {
+            drone_store_observe(t->addr, t->rssi,
+                                t->uas_id, t->id_type, t->ua_type,
+                                t->has_basic != 0, t->has_location != 0,
+                                t->lat_e7, t->lon_e7, t->alt_geoid_m,
+                                t->speed_cm_s, t->heading_deg,
+                                time_offer);
+            t->flash_ms = t->last_ms;
+        }
     }
 
     // Apply pending wall-clock from System message (main loop, not HCI).
     if (g_pending_sync) {
         g_pending_sync = false;
         uint32_t unix = g_pending_unix;
+        int8_t rssi = g_pending_rssi;
+        uint8_t q = drone_rssi_quality(rssi);
         bool apply = !het68_time_synced();
         if (!apply) {
             uint32_t cur = het68_time_epoch_sec();
@@ -366,12 +388,14 @@ void remote_id_poll(void) {
         if (apply &&
             (het68_time_synced() ? ((now - g_last_rid_sync_ms) >= RID_TIME_MIN_GAP_MS)
                                  : true)) {
-            if (het68_time_sync(unix)) {
+            if (het68_time_sync_from(unix, HET68_TIME_SRC_RID, q)) {
                 g_last_rid_sync_ms = now;
                 g_time_sync_count++;
                 uint32_t lock = dbg_line_lock();
                 dbg_puts("TIME SYNC via RID epoch=");
                 dbg_putu32(unix);
+                dbg_puts(" quality=");
+                dbg_putu32(q);
                 dbg_puts(" (OpenDroneID System)\n");
                 dbg_line_unlock(lock);
             }

--- a/remote_id.h
+++ b/remote_id.h
@@ -23,6 +23,8 @@ typedef struct {
     uint16_t speed_cm_s;    // horizontal, approx cm/s
     uint16_t heading_deg;   // 0..359, 361 = unknown
     uint32_t last_ms;
+    uint32_t flash_ms;      // last_ms already persisted to drone_store
+    uint8_t  sys_pending;   // System msg seen since last main-loop observe
 } rid_track_t;
 
 // Returns true if BT RID is compiled in and init succeeded.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **`TIME INFO`** — reports wall-clock sync **source** (`uart` / `rid` / `none`), **age**, and **quality** (RSSI-based for RID, 100 for UART; decays ~1 pt/min).
- **Known drones in flash** — new ACID dual-slot store at sectors `[-8,-7]` (`drone_store`); OpenDroneID Basic ID / Location / System metadata persisted from the BLE scanner (`DRONE LIST` / `DRONE CLEAR`).
- **`STATUS`** — dumps time info, DET/ENT/drone/RID statistics, and all stored records; same dump runs **after boot**.
- Version bump to **1.1.2**. Flash end layout: DRONE / BT TLV / DET / ENT.

## Test plan
- [ ] `./build.sh` (pico2) succeeds
- [ ] `PICO_BOARD=pimoroni_pico_plus2_w_rp2350 ./build.sh` succeeds
- [ ] UART: `TIME INFO`, `STATUS`, `DRONE LIST` respond as documented
- [ ] On Plus 2 W with RID beacon: drone appears in `DRONE LIST` and survives reboot after idle flash commit
- [ ] Boot UART shows `=== STATUS 1.1.2 ===` block before HELP

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

