### PR TITLE
1.2.2: baro-corrected speed of sound for DOA + STATUS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,13 @@ set(SRCS
     het68_time.c
     cli.c
     remote_id.c
+    drone_store.c
 )
 
 add_executable(pico_6mic_soundcard ${SRCS})
 
 # Version stamp (UART help / docs). Semver core for releases.
-add_compile_definitions(HET68_VERSION_STR=\"1.1.1\")
+add_compile_definitions(HET68_VERSION_STR=\"1.1.2\")
 
 # PIO header po add_executable
 pico_generate_pio_header(pico_6mic_soundcard ${CMAKE_CURRENT_LIST_DIR}/pio/i2s_rx.pio)
@@ -111,8 +112,8 @@ target_link_libraries(pico_6mic_soundcard
 )
 
 # OpenDroneID BLE scanner on CYW43 boards (Pico W / Pico Plus 2 W).
-# Relocate BTstack TLV flash bank so it does not collide with DET/ENT ACID slots
-# (last 4 sectors): BT uses sectors [-6,-5], DET [-4,-3], ENT [-2,-1].
+# Flash end layout (4 KiB sectors): DRONE[-8,-7], BT[-6,-5], DET[-4,-3], ENT[-2,-1].
+# Relocate BTstack TLV so it does not collide with DRONE/DET/ENT ACID slots.
 if (PICO_CYW43_SUPPORTED)
     message(STATUS "het68: CYW43 board — enabling BLE OpenDroneID (HET68_BT_RID)")
     target_compile_definitions(pico_6mic_soundcard PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(SRCS
 add_executable(pico_6mic_soundcard ${SRCS})
 
 # Version stamp (UART help / docs). Semver core for releases.
-add_compile_definitions(HET68_VERSION_STR=\"1.2.1\")
+add_compile_definitions(HET68_VERSION_STR=\"1.2.2\")
 
 # PIO header po add_executable
 pico_generate_pio_header(pico_6mic_soundcard ${CMAKE_CURRENT_LIST_DIR}/pio/i2s_rx.pio)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,13 @@ set(SRCS
     cli.c
     remote_id.c
     drone_store.c
+    dps310.c
 )
 
 add_executable(pico_6mic_soundcard ${SRCS})
 
 # Version stamp (UART help / docs). Semver core for releases.
-add_compile_definitions(HET68_VERSION_STR=\"1.1.2\")
+add_compile_definitions(HET68_VERSION_STR=\"1.2.1\")
 
 # PIO header po add_executable
 pico_generate_pio_header(pico_6mic_soundcard ${CMAKE_CURRENT_LIST_DIR}/pio/i2s_rx.pio)
@@ -107,6 +108,7 @@ target_link_libraries(pico_6mic_soundcard
     hardware_dma
     hardware_clocks
     hardware_pwm
+    hardware_i2c
     tinyusb_device
     tinyusb_board
 )

--- a/README.md
+++ b/README.md
@@ -175,9 +175,10 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   `TIME SYNC <unix>` since boot. `DET EXPORT` emits **JSON Lines** (`NVREVT`) for
   smart-NVR event correlation.
 
-  UART **CLI** (help on boot / first byte / USB mount): `HELP`, `TIME` /
-  `TIME SYNC`, `LOG ON|OFF`, `DET LIST|EXPORT|BACKUP|IMPORT|DEL|CLEAR`,
-  `ENT LIST|EXPORT|IMPORT`, `RID LIST|ON|OFF`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
+  UART **CLI** (help on boot / first byte / USB mount): `HELP`, `STATUS`,
+  `TIME` / `TIME INFO` / `TIME SYNC`, `LOG ON|OFF`,
+  `DET LIST|EXPORT|BACKUP|IMPORT|DEL|CLEAR`, `ENT LIST|EXPORT|IMPORT`,
+  `DRONE LIST|CLEAR`, `RID LIST|ON|OFF`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
 
 * **OpenDroneID / EU Direct Remote ID (v1.1.0+).** On CYW43 boards
   (`PICO_BOARD=pimoroni_pico_plus2_w_rp2350` or other Pico W variants) the
@@ -186,9 +187,11 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   Tracks show up in the heartbeat as `rid=N`, via `RID LIST`, and as DET class
   `remoteid`. **v1.1.1:** System-message timestamp (ODID 2019 epoch → Unix)
   auto-applies `TIME SYNC` when unsynced or when drift ≥ 2 s (rate-limited), so
-  DET timestamps work without a UART `TIME SYNC`. Non-wireless `pico2` builds
-  compile a stub. BTstack flash TLV is relocated so it does not overlap DET/ENT
-  ACID sectors.
+  DET timestamps work without a UART `TIME SYNC`. **v1.1.2:** `TIME INFO`
+  reports sync **source / age / quality**; known drones (+ RID fields) persist
+  in a flash ACID store (`DRONE LIST`); `STATUS` dumps all stored data and
+  statistics (also printed on boot). Non-wireless `pico2` builds compile a
+  stub. Flash end layout: DRONE / BT TLV / DET / ENT (two sectors each).
 
   ```
   SRC class=wind az=180.0 el=10.0 inten=-22.5dB

--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ Passive piezo between the two signal wires. **Do not use red or black** on this 
 | **I2C1** | Piezo beacon | GP6, GP7 |
 | **D16 / D18 / D20** | Mic 1–3 SD | GP16 / GP18 / GP20 |
 | **A0 / A1 / A2** | Mic 4–6 SD (pin 1) | GP26 / GP27 / GP28 |
+| *(header)* | Grove DPS310 barometer (optional) | **GP2 SDA / GP3 SCL** (I2C1) |
+
+### Barometer — Grove DPS310 (optional, v1.2.1+)
+
+**Seeed 101020812** Infineon DPS310 (300–1200 hPa, −40–85 °C). Wire to free
+header pins **GP2 (SDA) / GP3 (SCL)** + 3V3/GND — **not** to shield I2C0/I2C1
+(those are mic clocks / piezo). Firmware probes `0x77` then `0x76`; if the pins
+are busy or no device answers, baro is skipped. CLI: `BARO` (aliases `DPS`,
+`PRESSURE`); also in `STATUS`, boot dump, and heartbeat (`baro=…hPa`).
+Details: [`wiring_and_bom.md`](wiring_and_bom.md),
+[Seeed wiki](https://wiki.seeedstudio.com/Grove-High-Precision-Barometric-Pressure-Sensor-DPS310/).
 
 BOM and module layout: `wiring_and_bom.md`.
 
@@ -178,7 +189,7 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   UART **CLI** (help on boot / first byte / USB mount): `HELP`, `STATUS`,
   `TIME` / `TIME INFO` / `TIME SYNC`, `LOG ON|OFF`,
   `DET LIST|EXPORT|BACKUP|IMPORT|DEL|CLEAR`, `ENT LIST|EXPORT|IMPORT`,
-  `DRONE LIST|CLEAR`, `RID LIST|ON|OFF`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
+  `DRONE LIST|CLEAR`, `BARO`, `RID LIST|ON|OFF`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
 
 * **OpenDroneID / EU Direct Remote ID (v1.1.0+).** On CYW43 boards
   (`PICO_BOARD=pimoroni_pico_plus2_w_rp2350` or other Pico W variants) the
@@ -190,8 +201,9 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   DET timestamps work without a UART `TIME SYNC`. **v1.1.2:** `TIME INFO`
   reports sync **source / age / quality**; known drones (+ RID fields) persist
   in a flash ACID store (`DRONE LIST`); `STATUS` dumps all stored data and
-  statistics (also printed on boot). Non-wireless `pico2` builds compile a
-  stub. Flash end layout: DRONE / BT TLV / DET / ENT (two sectors each).
+  statistics (also printed on boot). **v1.2.1:** optional Grove **DPS310**
+  barometer on GP2/GP3 (`BARO`). Non-wireless `pico2` builds compile a stub
+  for RID. Flash end layout: DRONE / BT TLV / DET / ENT (two sectors each).
 
   ```
   SRC class=wind az=180.0 el=10.0 inten=-22.5dB

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ header pins **GP2 (SDA) / GP3 (SCL)** + 3V3/GND — **not** to shield I2C0/I2C1
 (those are mic clocks / piezo). Firmware probes `0x77` then `0x76`; if the pins
 are busy or no device answers, baro is skipped. CLI: `BARO` (aliases `DPS`,
 `PRESSURE`); also in `STATUS`, boot dump, and heartbeat (`baro=…hPa`).
+**v1.2.2:** dry-air speed of sound from temperature
+(`c = 331.3√(1+T/273.15)`) is shown as `SOUND c=…m/s` in `STATUS` stats /
+`BARO`, and fed into DOA TDOA (default 343 m/s when baro absent).
 Details: [`wiring_and_bom.md`](wiring_and_bom.md),
 [Seeed wiki](https://wiki.seeedstudio.com/Grove-High-Precision-Barometric-Pressure-Sensor-DPS310/).
 

--- a/cli.c
+++ b/cli.c
@@ -3,6 +3,7 @@
 #include "debug_io.h"
 #include "entity_store.h"
 #include "detection_log.h"
+#include "drone_store.h"
 #include "het68_time.h"
 #include "remote_id.h"
 #include <string.h>
@@ -23,7 +24,9 @@ void cli_print_help(void) {
 #endif
     dbg_puts(" ===\n");
     dbg_puts("HELP                 — this help\n");
+    dbg_puts("STATUS               — all stored data + statistics\n");
     dbg_puts("TIME                 — show clock / sync status\n");
+    dbg_puts("TIME INFO            — time source, age, quality\n");
     dbg_puts("TIME SYNC <unix>     — sync wall clock (required for DET timestamps)\n");
     dbg_puts("LOG ON | LOG OFF     — enable/disable SRC/ENTITY stdout logging\n");
     dbg_puts("LOG                  — show log status\n");
@@ -35,10 +38,63 @@ void cli_print_help(void) {
     dbg_puts("DET CLEAR            — delete all detections\n");
     dbg_puts("ENT LIST             — entity gallery (classification templates)\n");
     dbg_puts("ENT EXPORT|IMPORT    — gallery hex blob transfer\n");
+    dbg_puts("DRONE LIST           — known drones persisted in flash\n");
+    dbg_puts("DRONE CLEAR          — erase known-drone flash registry\n");
     dbg_puts("RID LIST             — OpenDroneID BLE tracks (CYW43 boards)\n");
     dbg_puts("RID ON | RID OFF     — enable/disable BLE Remote ID scan\n");
     dbg_puts("Note: DET timestamps after TIME SYNC (UART or RID System msg).\n");
     dbg_puts("=================\n");
+    dbg_line_unlock(lock);
+}
+
+void cli_print_status(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("=== STATUS ");
+#ifdef HET68_VERSION_STR
+    dbg_puts(HET68_VERSION_STR);
+#else
+    dbg_puts("?");
+#endif
+    dbg_puts(" ===\n");
+    dbg_line_unlock(lock);
+
+    het68_time_info_uart();
+
+    lock = dbg_line_lock();
+    dbg_puts("--- stats ---\n");
+    dbg_puts("DET n=");
+    dbg_putu32(detection_log_count());
+    if (detection_log_dirty()) dbg_puts(" dirty");
+    if (detection_log_saving()) dbg_puts(" saving");
+    dbg_putc('\n');
+    dbg_puts("ENT n=");
+    dbg_putu32(entity_store_count());
+    if (entity_store_dirty()) dbg_puts(" dirty");
+    if (entity_store_saving()) dbg_puts(" saving");
+    dbg_putc('\n');
+    drone_store_stats_uart();
+    dbg_puts("RID live=");
+    dbg_putu32(remote_id_active_count());
+    dbg_puts(" avail=");
+    dbg_puts(remote_id_available() ? "1" : "0");
+    dbg_puts(" scan=");
+    dbg_puts(remote_id_enabled() ? "on" : "off");
+    dbg_puts(" syncs=");
+    dbg_putu32(remote_id_time_sync_count());
+    dbg_putc('\n');
+    dbg_puts("LOG stdout=");
+    dbg_puts(dbg_log_enabled() ? "on" : "off");
+    dbg_putc('\n');
+    dbg_line_unlock(lock);
+
+    entity_store_dump_uart();
+    detection_log_list_uart();
+    drone_store_list_uart();
+    if (remote_id_available())
+        remote_id_list_uart();
+
+    lock = dbg_line_lock();
+    dbg_puts("=== end STATUS ===\n");
     dbg_line_unlock(lock);
 }
 
@@ -96,8 +152,17 @@ static void handle_line(char *line) {
         return;
     }
 
+    if (strcmp(line, "STATUS") == 0) {
+        cli_print_status();
+        return;
+    }
+
     if (strcmp(line, "TIME") == 0) {
         het68_time_dump_uart();
+        return;
+    }
+    if (strcmp(line, "TIME INFO") == 0) {
+        het68_time_info_uart();
         return;
     }
     if (strncmp(line, "TIME SYNC ", 10) == 0) {
@@ -105,6 +170,8 @@ static void handle_line(char *line) {
         if (het68_time_sync(ep)) {
             dbg_puts("TIME OK epoch=");
             dbg_putu32(het68_time_epoch_sec());
+            dbg_puts(" source=uart quality=");
+            dbg_putu32(het68_time_quality());
             dbg_putc('\n');
         } else {
             dbg_puts("TIME ERR: need unix epoch >= 1700000000\n");
@@ -184,6 +251,16 @@ static void handle_line(char *line) {
         return;
     }
 
+    if (strcmp(line, "DRONE LIST") == 0 || strcmp(line, "DRONE") == 0) {
+        drone_store_list_uart();
+        return;
+    }
+    if (strcmp(line, "DRONE CLEAR") == 0) {
+        if (drone_store_clear()) dbg_puts("DRONE CLEAR OK (pending flash)\n");
+        else dbg_puts("DRONE CLEAR ERR: busy\n");
+        return;
+    }
+
     if (strcmp(line, "RID LIST") == 0 || strcmp(line, "RID") == 0) {
         remote_id_list_uart();
         return;
@@ -209,7 +286,8 @@ static void handle_line(char *line) {
 
     if (strncmp(line, "DET", 3) == 0 || strncmp(line, "ENT", 3) == 0 ||
         strncmp(line, "TIME", 4) == 0 || strncmp(line, "LOG", 3) == 0 ||
-        strncmp(line, "RID", 3) == 0) {
+        strncmp(line, "RID", 3) == 0 || strncmp(line, "DRONE", 5) == 0 ||
+        strncmp(line, "STATUS", 6) == 0) {
         dbg_puts("?: unknown command — HELP\n");
     }
 }

--- a/cli.c
+++ b/cli.c
@@ -4,6 +4,7 @@
 #include "entity_store.h"
 #include "detection_log.h"
 #include "drone_store.h"
+#include "dps310.h"
 #include "het68_time.h"
 #include "remote_id.h"
 #include <string.h>
@@ -40,6 +41,7 @@ void cli_print_help(void) {
     dbg_puts("ENT EXPORT|IMPORT    — gallery hex blob transfer\n");
     dbg_puts("DRONE LIST           — known drones persisted in flash\n");
     dbg_puts("DRONE CLEAR          — erase known-drone flash registry\n");
+    dbg_puts("BARO                 — Grove DPS310 pressure/temperature (GP2/GP3)\n");
     dbg_puts("RID LIST             — OpenDroneID BLE tracks (CYW43 boards)\n");
     dbg_puts("RID ON | RID OFF     — enable/disable BLE Remote ID scan\n");
     dbg_puts("Note: DET timestamps after TIME SYNC (UART or RID System msg).\n");
@@ -87,6 +89,7 @@ void cli_print_status(void) {
     dbg_putc('\n');
     dbg_line_unlock(lock);
 
+    dps310_dump_uart();
     entity_store_dump_uart();
     detection_log_list_uart();
     drone_store_list_uart();
@@ -261,6 +264,13 @@ static void handle_line(char *line) {
         return;
     }
 
+    if (strcmp(line, "BARO") == 0 || strcmp(line, "DPS") == 0 ||
+        strcmp(line, "PRESSURE") == 0) {
+        dps310_poll();
+        dps310_dump_uart();
+        return;
+    }
+
     if (strcmp(line, "RID LIST") == 0 || strcmp(line, "RID") == 0) {
         remote_id_list_uart();
         return;
@@ -287,6 +297,7 @@ static void handle_line(char *line) {
     if (strncmp(line, "DET", 3) == 0 || strncmp(line, "ENT", 3) == 0 ||
         strncmp(line, "TIME", 4) == 0 || strncmp(line, "LOG", 3) == 0 ||
         strncmp(line, "RID", 3) == 0 || strncmp(line, "DRONE", 5) == 0 ||
+        strncmp(line, "BARO", 4) == 0 || strncmp(line, "DPS", 3) == 0 ||
         strncmp(line, "STATUS", 6) == 0) {
         dbg_puts("?: unknown command — HELP\n");
     }

--- a/cli.c
+++ b/cli.c
@@ -5,6 +5,7 @@
 #include "detection_log.h"
 #include "drone_store.h"
 #include "dps310.h"
+#include "doa.h"
 #include "het68_time.h"
 #include "remote_id.h"
 #include <string.h>
@@ -87,6 +88,21 @@ void cli_print_status(void) {
     dbg_puts("LOG stdout=");
     dbg_puts(dbg_log_enabled() ? "on" : "off");
     dbg_putc('\n');
+    {
+        float c = dps310_speed_of_sound_m_s();
+        bool from_baro = (c > 0.0f);
+        if (!from_baro) c = doa_c_sound_m_s();
+        dbg_puts("SOUND c=");
+        // one decimal m/s
+        int32_t t = (int32_t)(c * 10.0f + (c >= 0.0f ? 0.5f : -0.5f));
+        if (t < 0) { dbg_putc('-'); t = -t; }
+        dbg_putu32((uint32_t)(t / 10));
+        dbg_putc('.');
+        dbg_putu32((uint32_t)(t % 10));
+        dbg_puts("m/s src=");
+        dbg_puts(from_baro ? "baro" : "default");
+        dbg_putc('\n');
+    }
     dbg_line_unlock(lock);
 
     dps310_dump_uart();

--- a/cli.h
+++ b/cli.h
@@ -1,9 +1,12 @@
-// cli.h — simple UART CLI (help, time, log, DET, ENT).
+// cli.h — simple UART CLI (help, time, status, DET, ENT, RID, drones).
 #pragma once
 #include <stdbool.h>
 
 void cli_init(void);
 void cli_print_help(void);
+
+// Aggregated dump: time source/quality, DET/ENT/drone flash stats + contents.
+void cli_print_status(void);
 
 // Feed one received byte (non-blocking). Handles line assembly + commands.
 void cli_rx_byte(int ch);

--- a/doa.c
+++ b/doa.c
@@ -52,10 +52,23 @@ static const float MIC_DIR[6][3] = {
 static float MIC_POS[6][3];
 
 #define DOA_FS_HZ        48000
+// Nominal 20 °C; buffer sizing uses cold extreme so runtime baro correction fits.
 #define DOA_C_MM_S       343000
+#define DOA_C_MM_S_MIN   300000   // ~-40 °C dry air — sizes DOA_MAXLAG
 #define DOA_FS           ((float)DOA_FS_HZ)
 #define DOA_C_SOUND      (DOA_C_MM_S * 0.001f)
-#define DOA_MAXLAG       ((DOA_EDGE_MM * DOA_FS_HZ + DOA_C_MM_S - 1) / DOA_C_MM_S + 2)
+#define DOA_MAXLAG       ((DOA_EDGE_MM * DOA_FS_HZ + DOA_C_MM_S_MIN - 1) / DOA_C_MM_S_MIN + 2)
+
+// Updated from core0 when DPS310 temperature is available (default 343 m/s).
+static volatile float g_c_sound_m_s = DOA_C_SOUND;
+
+void doa_set_c_sound_m_s(float c_m_s) {
+    if (c_m_s < 300.0f) c_m_s = 300.0f;
+    if (c_m_s > 380.0f) c_m_s = 380.0f;
+    g_c_sound_m_s = c_m_s;
+}
+
+float doa_c_sound_m_s(void) { return g_c_sound_m_s; }
 
 #if   DOA_MAXLAG <= 85
 #define DOA_N            256u
@@ -578,7 +591,7 @@ static doa_fix_t solve_tdoa(const bool active[6]) {
             MIC_POS[i][1] - MIC_POS[ref][1],
             MIC_POS[i][2] - MIC_POS[ref][2],
         };
-        float bb = DOA_TDOA_SIGN * (-DOA_C_SOUND / DOA_FS) * lag;
+        float bb = DOA_TDOA_SIGN * (-g_c_sound_m_s / DOA_FS) * lag;
         for (int r = 0; r < 3; r++) {
             for (int cc = 0; cc < 3; cc++) AtA[r][cc] += conf * row[r] * row[cc];
             Atb[r] += conf * row[r] * bb;
@@ -612,7 +625,7 @@ static void cancel_direction(const float dir[3], int ref) {
         float dy = MIC_POS[i][1] - MIC_POS[ref][1];
         float dz = MIC_POS[i][2] - MIC_POS[ref][2];
         float lag_f = DOA_TDOA_SIGN * (dx * dir[0] + dy * dir[1] + dz * dir[2])
-                      * (DOA_FS / DOA_C_SOUND);
+                      * (DOA_FS / g_c_sound_m_s);
         int lag = (int)((lag_f >= 0.0f) ? (lag_f + 0.5f) : (lag_f - 0.5f));
         if (lag < -DOA_MAXLAG) lag = -DOA_MAXLAG;
         if (lag > DOA_MAXLAG) lag = DOA_MAXLAG;

--- a/doa.h
+++ b/doa.h
@@ -5,6 +5,10 @@
 void doa_ring_push(const int16_t s6[6]);
 void doa_start(void);
 
+// Runtime speed of sound for TDOA (m/s). Default 343; updated from baro when present.
+void doa_set_c_sound_m_s(float c_m_s);
+float doa_c_sound_m_s(void);
+
 extern volatile uint32_t g_doa_out;
 extern volatile uint32_t g_doa_nactive;
 extern volatile uint32_t g_doa_iter;

--- a/dps310.c
+++ b/dps310.c
@@ -1,0 +1,309 @@
+// dps310.c — Infineon DPS310 over hardware I2C1 on GP2/GP3.
+//
+// Continuous pressure+temperature (32 Hz, 16× OS) with datasheet compensation.
+// Init may sleep (~50 ms); poll/read never block the audio path.
+#include "dps310.h"
+#include "debug_io.h"
+#include "hardware/gpio.h"
+#include "hardware/i2c.h"
+#include "pico/stdlib.h"
+#include <math.h>
+#include <string.h>
+
+#define DPS310_I2C          i2c1
+#define DPS310_I2C_HZ       400000u
+
+#define REG_PSR_B2          0x00u
+#define REG_PRS_CFG         0x06u
+#define REG_TMP_CFG         0x07u
+#define REG_MEAS_CFG        0x08u
+#define REG_CFG_REG         0x09u
+#define REG_RESET           0x0Cu
+#define REG_PRODUCT_ID      0x0Du
+#define REG_COEF            0x10u
+#define REG_COEF_SRCE       0x28u
+
+#define PRODUCT_ID_DPS310   0x10u
+#define SOFT_RST            0x09u
+
+#define MEAS_COEF_RDY       0x80u
+#define MEAS_SENSOR_RDY     0x40u
+#define MEAS_TMP_RDY        0x20u
+#define MEAS_PRS_RDY        0x10u
+#define MEAS_CTRL_CONT_PT   0x07u
+
+#define CFG_T_SHIFT         0x08u
+#define CFG_P_SHIFT         0x04u
+
+#define TMP_COEF_SRCE       0x80u
+
+// 32 Hz rate + 16× oversampling (kT/kP = 253952 with result bit-shift)
+#define PRS_CFG_32HZ_16X    0x54u
+#define TMP_CFG_32HZ_16X    0x54u
+
+#define SCALE_16X           253952.0f
+#define SEA_LEVEL_PA        101325.0f
+
+static bool g_ok;
+static uint8_t g_addr;
+static int32_t g_c0, g_c1, g_c00, g_c10, g_c01, g_c11, g_c20, g_c21, g_c30;
+static float g_pressure_pa;
+static float g_temperature_c;
+static uint32_t g_sample_ms;
+static bool g_have_sample;
+
+static int32_t twos_complement(uint32_t raw, uint8_t bits) {
+    uint32_t sign = 1u << (bits - 1u);
+    if (raw & sign)
+        return (int32_t)raw - (int32_t)(1u << bits);
+    return (int32_t)raw;
+}
+
+static bool i2c_write_reg(uint8_t reg, uint8_t val) {
+    uint8_t buf[2] = { reg, val };
+    int n = i2c_write_blocking(DPS310_I2C, g_addr, buf, 2, false);
+    return n == 2;
+}
+
+static bool i2c_read_regs(uint8_t reg, uint8_t *dst, size_t len) {
+    if (i2c_write_blocking(DPS310_I2C, g_addr, &reg, 1, true) != 1)
+        return false;
+    return i2c_read_blocking(DPS310_I2C, g_addr, dst, len, false) == (int)len;
+}
+
+static bool i2c_read_u8(uint8_t reg, uint8_t *val) {
+    return i2c_read_regs(reg, val, 1);
+}
+
+static bool probe_addr(uint8_t addr) {
+    uint8_t reg = REG_PRODUCT_ID;
+    uint8_t id = 0;
+    if (i2c_write_blocking(DPS310_I2C, addr, &reg, 1, true) != 1)
+        return false;
+    if (i2c_read_blocking(DPS310_I2C, addr, &id, 1, false) != 1)
+        return false;
+    return id == PRODUCT_ID_DPS310;
+}
+
+static bool pins_look_free(void) {
+    // Reject if already claimed by a non-SIO/I2C function (e.g. SPI/UART/PWM).
+    uint f2 = gpio_get_function(DPS310_I2C_SDA_PIN);
+    uint f3 = gpio_get_function(DPS310_I2C_SCL_PIN);
+    if (f2 != GPIO_FUNC_SIO && f2 != GPIO_FUNC_NULL && f2 != GPIO_FUNC_I2C)
+        return false;
+    if (f3 != GPIO_FUNC_SIO && f3 != GPIO_FUNC_NULL && f3 != GPIO_FUNC_I2C)
+        return false;
+    return true;
+}
+
+static bool load_coefficients(void) {
+    uint8_t coef[18];
+    if (!i2c_read_regs(REG_COEF, coef, sizeof(coef)))
+        return false;
+
+    g_c0  = twos_complement(((uint32_t)coef[0] << 4) | ((coef[1] >> 4) & 0x0Fu), 12);
+    g_c1  = twos_complement((((uint32_t)coef[1] & 0x0Fu) << 8) | coef[2], 12);
+    g_c00 = twos_complement(((uint32_t)coef[3] << 12) | ((uint32_t)coef[4] << 4) |
+                            ((coef[5] >> 4) & 0x0Fu), 20);
+    g_c10 = twos_complement((((uint32_t)coef[5] & 0x0Fu) << 16) |
+                            ((uint32_t)coef[6] << 8) | coef[7], 20);
+    g_c01 = twos_complement(((uint32_t)coef[8] << 8) | coef[9], 16);
+    g_c11 = twos_complement(((uint32_t)coef[10] << 8) | coef[11], 16);
+    g_c20 = twos_complement(((uint32_t)coef[12] << 8) | coef[13], 16);
+    g_c21 = twos_complement(((uint32_t)coef[14] << 8) | coef[15], 16);
+    g_c30 = twos_complement(((uint32_t)coef[16] << 8) | coef[17], 16);
+    return true;
+}
+
+static bool configure_continuous(void) {
+    uint8_t coef_srce = 0;
+    (void)i2c_read_u8(REG_COEF_SRCE, &coef_srce);
+    uint8_t tmp_ext = (uint8_t)(coef_srce & TMP_COEF_SRCE);
+
+    if (!i2c_write_reg(REG_PRS_CFG, PRS_CFG_32HZ_16X)) return false;
+    if (!i2c_write_reg(REG_TMP_CFG, (uint8_t)(TMP_CFG_32HZ_16X | tmp_ext))) return false;
+    if (!i2c_write_reg(REG_CFG_REG, (uint8_t)(CFG_T_SHIFT | CFG_P_SHIFT))) return false;
+    // Datasheet/Linux: write 0 before enabling continuous mode.
+    if (!i2c_write_reg(REG_MEAS_CFG, 0x00u)) return false;
+    if (!i2c_write_reg(REG_MEAS_CFG, MEAS_CTRL_CONT_PT)) return false;
+    return true;
+}
+
+bool dps310_init(void) {
+    g_ok = false;
+    g_addr = 0;
+    g_have_sample = false;
+    g_pressure_pa = 0.0f;
+    g_temperature_c = 0.0f;
+    g_sample_ms = 0;
+
+    if (!pins_look_free()) {
+        dbg_puts("BARO: pin GP2/GP3 busy — DPS310 skipped\n");
+        return false;
+    }
+
+    i2c_init(DPS310_I2C, DPS310_I2C_HZ);
+    gpio_set_function(DPS310_I2C_SDA_PIN, GPIO_FUNC_I2C);
+    gpio_set_function(DPS310_I2C_SCL_PIN, GPIO_FUNC_I2C);
+    gpio_pull_up(DPS310_I2C_SDA_PIN);
+    gpio_pull_up(DPS310_I2C_SCL_PIN);
+
+    uint8_t try_addrs[2] = { 0x77u, 0x76u };
+    for (int i = 0; i < 2; i++) {
+        if (probe_addr(try_addrs[i])) {
+            g_addr = try_addrs[i];
+            break;
+        }
+    }
+    if (!g_addr) {
+        // Release pins so another peripheral can use them later.
+        gpio_set_function(DPS310_I2C_SDA_PIN, GPIO_FUNC_NULL);
+        gpio_set_function(DPS310_I2C_SCL_PIN, GPIO_FUNC_NULL);
+        i2c_deinit(DPS310_I2C);
+        dbg_puts("BARO: no DPS310 on GP2/GP3 (I2C1)\n");
+        return false;
+    }
+
+    if (!i2c_write_reg(REG_RESET, SOFT_RST)) {
+        dbg_puts("BARO: soft reset failed\n");
+        return false;
+    }
+    sleep_ms(50);
+
+    uint8_t meas = 0;
+    for (int i = 0; i < 20; i++) {
+        if (!i2c_read_u8(REG_MEAS_CFG, &meas)) {
+            dbg_puts("BARO: MEAS_CFG read failed\n");
+            return false;
+        }
+        if ((meas & MEAS_COEF_RDY) && (meas & MEAS_SENSOR_RDY))
+            break;
+        sleep_ms(5);
+    }
+    if (!((meas & MEAS_COEF_RDY) && (meas & MEAS_SENSOR_RDY))) {
+        dbg_puts("BARO: coeffs/sensor not ready\n");
+        return false;
+    }
+
+    if (!load_coefficients() || !configure_continuous()) {
+        dbg_puts("BARO: configure failed\n");
+        return false;
+    }
+
+    g_ok = true;
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("BARO: DPS310 OK I2C1 GP2/GP3 addr=0x");
+    dbg_puthex8(g_addr);
+    dbg_puts(" (continuous 32Hz/16x)\n");
+    dbg_line_unlock(lock);
+    return true;
+}
+
+bool dps310_available(void) { return g_ok; }
+uint8_t dps310_i2c_addr(void) { return g_ok ? g_addr : 0; }
+
+void dps310_poll(void) {
+    if (!g_ok) return;
+
+    // Keep I2C traffic light — sample at ~10 Hz max from the main loop.
+    static uint32_t s_last_poll_ms;
+    uint32_t now = to_ms_since_boot(get_absolute_time());
+    if ((now - s_last_poll_ms) < 100u) return;
+    s_last_poll_ms = now;
+
+    uint8_t meas = 0;
+    if (!i2c_read_u8(REG_MEAS_CFG, &meas)) return;
+    if (!(meas & MEAS_PRS_RDY)) return;
+
+    uint8_t buf[6];
+    if (!i2c_read_regs(REG_PSR_B2, buf, sizeof(buf))) return;
+
+    int32_t praw = twos_complement(((uint32_t)buf[0] << 16) |
+                                   ((uint32_t)buf[1] << 8) | buf[2], 24);
+    int32_t traw = twos_complement(((uint32_t)buf[3] << 16) |
+                                   ((uint32_t)buf[4] << 8) | buf[5], 24);
+
+    const float praw_sc = (float)praw / SCALE_16X;
+    const float traw_sc = (float)traw / SCALE_16X;
+
+    const float pcomp =
+        (float)g_c00 +
+        praw_sc * ((float)g_c10 + praw_sc * ((float)g_c20 + praw_sc * (float)g_c30)) +
+        traw_sc * (float)g_c01 +
+        traw_sc * praw_sc * ((float)g_c11 + praw_sc * (float)g_c21);
+    const float tcomp = (float)g_c0 * 0.5f + (float)g_c1 * traw_sc;
+
+    // Sanity: DPS310 operating window
+    if (pcomp < 20000.0f || pcomp > 130000.0f) return;
+    if (tcomp < -50.0f || tcomp > 95.0f) return;
+
+    g_pressure_pa = pcomp;
+    g_temperature_c = tcomp;
+    g_sample_ms = to_ms_since_boot(get_absolute_time());
+    g_have_sample = true;
+}
+
+bool dps310_read(dps310_sample_t *out) {
+    if (!out || !g_have_sample) return false;
+    out->pressure_pa = g_pressure_pa;
+    out->temperature_c = g_temperature_c;
+    uint32_t now = to_ms_since_boot(get_absolute_time());
+    out->age_ms = now - g_sample_ms;
+    return true;
+}
+
+float dps310_pressure_hpa(void) {
+    return g_have_sample ? (g_pressure_pa * 0.01f) : 0.0f;
+}
+
+float dps310_temperature_c(void) {
+    return g_have_sample ? g_temperature_c : 0.0f;
+}
+
+float dps310_altitude_m(void) {
+    if (!g_have_sample) return 0.0f;
+    // International barometric formula, QNH 1013.25 hPa
+    float ratio = g_pressure_pa / SEA_LEVEL_PA;
+    if (ratio <= 0.0f) return 0.0f;
+    return 44330.0f * (1.0f - powf(ratio, 0.19029495f));
+}
+
+static void put_f1(float v) {
+    if (v < 0.0f) { dbg_putc('-'); v = -v; }
+    uint32_t ip = (uint32_t)v;
+    uint32_t fp = (uint32_t)((v - (float)ip) * 10.0f + 0.5f);
+    if (fp >= 10u) { ip++; fp = 0u; }
+    dbg_putu32(ip);
+    dbg_putc('.');
+    dbg_putu32(fp);
+}
+
+void dps310_dump_uart(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("BARO");
+    if (!g_ok) {
+        dbg_puts(" avail=0\n");
+        dbg_line_unlock(lock);
+        return;
+    }
+    dbg_puts(" avail=1 addr=0x");
+    dbg_puthex8(g_addr);
+    dbg_puts(" pins=GP2/GP3");
+    if (!g_have_sample) {
+        dbg_puts(" (no sample yet)\n");
+        dbg_line_unlock(lock);
+        return;
+    }
+    dps310_sample_t s;
+    (void)dps310_read(&s);
+    dbg_puts(" P=");
+    put_f1(s.pressure_pa * 0.01f);
+    dbg_puts("hPa T=");
+    put_f1(s.temperature_c);
+    dbg_puts("C alt=");
+    put_f1(dps310_altitude_m());
+    dbg_puts("m age_ms=");
+    dbg_putu32(s.age_ms);
+    dbg_putc('\n');
+    dbg_line_unlock(lock);
+}

--- a/dps310.c
+++ b/dps310.c
@@ -268,6 +268,16 @@ float dps310_altitude_m(void) {
     return 44330.0f * (1.0f - powf(ratio, 0.19029495f));
 }
 
+float dps310_speed_of_sound_m_s(void) {
+    if (!g_have_sample) return 0.0f;
+    // Dry air (ISO approximation): c = 331.3 * sqrt(T_K / 273.15).
+    // DPS310 has no humidity; moist air would be slightly faster.
+    float tk = g_temperature_c + 273.15f;
+    if (tk < 233.15f) tk = 233.15f; // clamp ~-40 °C
+    if (tk > 358.15f) tk = 358.15f; // clamp ~+85 °C
+    return 331.3f * sqrtf(tk / 273.15f);
+}
+
 static void put_f1(float v) {
     if (v < 0.0f) { dbg_putc('-'); v = -v; }
     uint32_t ip = (uint32_t)v;
@@ -302,7 +312,9 @@ void dps310_dump_uart(void) {
     put_f1(s.temperature_c);
     dbg_puts("C alt=");
     put_f1(dps310_altitude_m());
-    dbg_puts("m age_ms=");
+    dbg_puts("m c=");
+    put_f1(dps310_speed_of_sound_m_s());
+    dbg_puts("m/s age_ms=");
     dbg_putu32(s.age_ms);
     dbg_putc('\n');
     dbg_line_unlock(lock);

--- a/dps310.h
+++ b/dps310.h
@@ -1,0 +1,33 @@
+// dps310.h — Grove DPS310 barometer on I2C1 (GP2 SDA / GP3 SCL).
+//
+// Seeed 101020812 — Infineon DPS310, I2C default 0x77 (alt 0x76).
+// Only claimed when GP2/GP3 are free and a device responds at probe.
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#define DPS310_I2C_SDA_PIN 2u
+#define DPS310_I2C_SCL_PIN 3u
+
+typedef struct {
+    float pressure_pa;   // compensated pressure (Pa)
+    float temperature_c; // compensated temperature (°C)
+    uint32_t age_ms;     // ms since last successful sample
+} dps310_sample_t;
+
+// Probe I2C, soft-reset, load coeffs, start continuous mode.
+// Returns false if pins busy / no ACK / wrong product ID.
+bool dps310_init(void);
+
+bool dps310_available(void);
+uint8_t dps310_i2c_addr(void); // 0 if not available
+
+// Non-blocking: refresh cached sample when PRS_RDY (safe from main loop).
+void dps310_poll(void);
+
+bool dps310_read(dps310_sample_t *out); // false if never sampled
+float dps310_pressure_hpa(void);        // 0 if none
+float dps310_temperature_c(void);       // 0 if none
+float dps310_altitude_m(void);          // rough QNH=1013.25 hPa; 0 if none
+
+void dps310_dump_uart(void);

--- a/dps310.h
+++ b/dps310.h
@@ -30,4 +30,8 @@ float dps310_pressure_hpa(void);        // 0 if none
 float dps310_temperature_c(void);       // 0 if none
 float dps310_altitude_m(void);          // rough QNH=1013.25 hPa; 0 if none
 
+// Dry-air speed of sound from last temperature sample (m/s), or 0 if none.
+// c = 331.3 * sqrt(1 + T_C/273.15). Pressure alone does not change ideal-gas c.
+float dps310_speed_of_sound_m_s(void);
+
 void dps310_dump_uart(void);

--- a/drone_store.c
+++ b/drone_store.c
@@ -1,0 +1,407 @@
+// drone_store.c — RAM-first known-drone registry with opportunistic ACID flash.
+//
+// Flash layout (below BTstack TLV / DET / ENT):
+//   slot0 = PICO_FLASH_SIZE_BYTES - 8*FLASH_SECTOR_SIZE
+//   slot1 = PICO_FLASH_SIZE_BYTES - 7*FLASH_SECTOR_SIZE
+// Full layout end→start: ENT[-2,-1], DET[-4,-3], BT[-6,-5], DRONE[-8,-7].
+#include "drone_store.h"
+#include "debug_io.h"
+#include "het68_time.h"
+#include "hardware/flash.h"
+#include "hardware/sync.h"
+#include "pico/flash.h"
+#include "pico/stdlib.h"
+#include <string.h>
+
+#define DRONE_MAGIC   0x44383648u  /* 'H68D' LE */
+#define DRONE_VERSION 1u
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#error "PICO_FLASH_SIZE_BYTES must be defined by the board"
+#endif
+
+#define DRONE_SLOT0_OFF  (PICO_FLASH_SIZE_BYTES - 8u * FLASH_SECTOR_SIZE)
+#define DRONE_SLOT1_OFF  (PICO_FLASH_SIZE_BYTES - 7u * FLASH_SECTOR_SIZE)
+
+_Static_assert(sizeof(drone_blob_t) <= FLASH_SECTOR_SIZE,
+               "drone_blob_t must fit in one flash sector");
+
+#define DRONE_FLAG_BASIC    0x01u
+#define DRONE_FLAG_LOCATION 0x02u
+
+static drone_slot_t g_slots[DRONE_STORE_MAX];
+static uint32_t g_next_id = 1;
+static uint32_t g_count = 0;
+static uint32_t g_seq = 0;
+static uint32_t g_active_slot = 0;
+static volatile bool g_dirty = false;
+
+typedef enum {
+    SAVE_IDLE = 0,
+    SAVE_ERASE,
+    SAVE_PROG
+} save_phase_t;
+
+static save_phase_t g_phase = SAVE_IDLE;
+static uint32_t g_save_slot = 0;
+static uint32_t g_prog_off = 0;
+static uint8_t g_stage[FLASH_SECTOR_SIZE];
+
+static void put_i32(int32_t v) {
+    if (v < 0) {
+        dbg_putc('-');
+        dbg_putu32((uint32_t)(-v));
+    } else {
+        dbg_putu32((uint32_t)v);
+    }
+}
+
+static void put_mac(const uint8_t addr[6]) {
+    for (int b = 0; b < 6; b++) {
+        dbg_puthex8(addr[b]);
+        if (b < 5) dbg_putc(':');
+    }
+}
+
+uint8_t drone_rssi_quality(int8_t rssi) {
+    // Map typical BLE RSSI: -40 dBm → 100, -90 dBm → 20, clamp.
+    int q = 100 + ((int)rssi + 40) * 2; // -40→100, -90→0 before floor
+    if (q > 100) q = 100;
+    if (q < 20) q = 20;
+    if (rssi < -95) q = 10;
+    return (uint8_t)q;
+}
+
+static uint32_t crc32_update(uint32_t crc, const uint8_t *data, size_t len) {
+    crc = ~crc;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; b++)
+            crc = (crc & 1u) ? ((crc >> 1) ^ 0xEDB88320u) : (crc >> 1);
+    }
+    return ~crc;
+}
+
+uint32_t drone_blob_crc(const drone_blob_t *b) {
+    drone_blob_t tmp = *b;
+    tmp.crc = 0;
+    return crc32_update(0, (const uint8_t *)&tmp, sizeof(tmp));
+}
+
+static void recount(void) {
+    uint32_t n = 0;
+    for (uint32_t i = 0; i < DRONE_STORE_MAX; i++)
+        if (g_slots[i].used) n++;
+    g_count = n;
+}
+
+static bool slot_valid(const drone_blob_t *b) {
+    if (b->magic != DRONE_MAGIC) return false;
+    if (b->version != DRONE_VERSION) return false;
+    if (b->count > DRONE_STORE_MAX) return false;
+    return drone_blob_crc(b) == b->crc;
+}
+
+static void load_from_flash(void) {
+    const drone_blob_t *s0 = (const drone_blob_t *)(XIP_BASE + DRONE_SLOT0_OFF);
+    const drone_blob_t *s1 = (const drone_blob_t *)(XIP_BASE + DRONE_SLOT1_OFF);
+    memset(g_slots, 0, sizeof(g_slots));
+    g_next_id = 1;
+    g_count = 0;
+    g_seq = 0;
+    g_active_slot = 0;
+
+    bool v0 = slot_valid(s0);
+    bool v1 = slot_valid(s1);
+    const drone_blob_t *best = NULL;
+    if (v0 && v1) {
+        best = (s1->seq >= s0->seq) ? s1 : s0;
+        g_active_slot = (best == s1) ? 1u : 0u;
+    } else if (v0) {
+        best = s0;
+        g_active_slot = 0;
+    } else if (v1) {
+        best = s1;
+        g_active_slot = 1;
+    }
+    if (!best) return;
+
+    memcpy(g_slots, best->slots, sizeof(g_slots));
+    g_next_id = best->next_id ? best->next_id : 1;
+    g_seq = best->seq;
+    recount();
+}
+
+static void build_stage_blob(void) {
+    for (uint32_t i = 0; i < FLASH_SECTOR_SIZE; i++) g_stage[i] = 0xFFu;
+    drone_blob_t *b = (drone_blob_t *)g_stage;
+    memset(b, 0, sizeof(*b));
+    b->magic = DRONE_MAGIC;
+    b->version = DRONE_VERSION;
+    b->seq = g_seq + 1u;
+    b->next_id = g_next_id;
+    recount();
+    b->count = g_count;
+    memcpy(b->slots, g_slots, sizeof(g_slots));
+    b->crc = drone_blob_crc(b);
+}
+
+typedef struct { uint32_t off; uint32_t len; } flash_op_t;
+
+static void __not_in_flash_func(flash_erase_cb)(void *param) {
+    flash_op_t *op = (flash_op_t *)param;
+    flash_range_erase(op->off, FLASH_SECTOR_SIZE);
+}
+
+typedef struct {
+    uint32_t flash_off;
+    uint32_t stage_off;
+    uint32_t len;
+} flash_prog_t;
+
+static void __not_in_flash_func(flash_prog_page_cb)(void *param) {
+    flash_prog_t *op = (flash_prog_t *)param;
+    flash_range_program(op->flash_off, &g_stage[op->stage_off], op->len);
+}
+
+void drone_store_core_init(void) {
+    // flash_safe_execute_core_init is shared; entity_store already calls it.
+}
+
+void drone_store_init(void) {
+    load_from_flash();
+    g_dirty = false;
+    g_phase = SAVE_IDLE;
+}
+
+bool drone_store_dirty(void) { return g_dirty; }
+bool drone_store_saving(void) { return g_phase != SAVE_IDLE; }
+uint32_t drone_store_count(void) { return g_count; }
+uint32_t drone_store_seq(void) { return g_seq; }
+
+const drone_slot_t *drone_store_slot(uint32_t index) {
+    if (index >= DRONE_STORE_MAX) return NULL;
+    if (!g_slots[index].used) return NULL;
+    return &g_slots[index];
+}
+
+static int find_by_addr(const uint8_t addr[6]) {
+    for (uint32_t i = 0; i < DRONE_STORE_MAX; i++) {
+        if (!g_slots[i].used) continue;
+        if (memcmp(g_slots[i].addr, addr, 6) == 0) return (int)i;
+    }
+    return -1;
+}
+
+static int find_by_uas(const char *uas_id) {
+    if (!uas_id || !uas_id[0]) return -1;
+    for (uint32_t i = 0; i < DRONE_STORE_MAX; i++) {
+        if (!g_slots[i].used) continue;
+        if (g_slots[i].uas_id[0] == '\0') continue;
+        if (strncmp(g_slots[i].uas_id, uas_id, DRONE_UAS_ID_LEN) == 0)
+            return (int)i;
+    }
+    return -1;
+}
+
+static int alloc_slot(void) {
+    int free_i = -1;
+    int oldest_i = 0;
+    uint32_t oldest_last = UINT32_MAX;
+    uint32_t oldest_hits = UINT32_MAX;
+    for (uint32_t i = 0; i < DRONE_STORE_MAX; i++) {
+        if (!g_slots[i].used) {
+            if (free_i < 0) free_i = (int)i;
+            continue;
+        }
+        uint32_t last = g_slots[i].last_seen ? g_slots[i].last_seen : 0;
+        if (last < oldest_last ||
+            (last == oldest_last && g_slots[i].hits < oldest_hits)) {
+            oldest_last = last;
+            oldest_hits = g_slots[i].hits;
+            oldest_i = (int)i;
+        }
+    }
+    return (free_i >= 0) ? free_i : oldest_i;
+}
+
+void drone_store_observe(const uint8_t addr[6], int8_t rssi,
+                         const char *uas_id, uint8_t id_type, uint8_t ua_type,
+                         bool has_basic, bool has_location,
+                         int32_t lat_e7, int32_t lon_e7, int16_t alt_geoid_m,
+                         uint16_t speed_cm_s, uint16_t heading_deg,
+                         bool time_offer) {
+    if (!addr) return;
+
+    int idx = find_by_addr(addr);
+    if (idx < 0 && has_basic && uas_id && uas_id[0])
+        idx = find_by_uas(uas_id);
+
+    bool is_new = false;
+    if (idx < 0) {
+        idx = alloc_slot();
+        memset(&g_slots[idx], 0, sizeof(g_slots[idx]));
+        g_slots[idx].used = 1;
+        memcpy(g_slots[idx].addr, addr, 6);
+        g_slots[idx].heading_deg = 361;
+        is_new = true;
+        g_next_id++;
+        if (g_next_id == 0) g_next_id = 1;
+    }
+
+    drone_slot_t *s = &g_slots[idx];
+    memcpy(s->addr, addr, 6);
+    s->rssi = rssi;
+    s->quality = drone_rssi_quality(rssi);
+    if (has_basic && uas_id) {
+        strncpy(s->uas_id, uas_id, DRONE_UAS_ID_LEN - 1);
+        s->uas_id[DRONE_UAS_ID_LEN - 1] = '\0';
+        s->id_type = id_type;
+        s->ua_type = ua_type;
+        s->flags |= DRONE_FLAG_BASIC;
+    }
+    if (has_location) {
+        s->lat_e7 = lat_e7;
+        s->lon_e7 = lon_e7;
+        s->alt_geoid_m = alt_geoid_m;
+        s->speed_cm_s = speed_cm_s;
+        s->heading_deg = heading_deg;
+        s->flags |= DRONE_FLAG_LOCATION;
+    }
+    if (time_offer) s->time_offers++;
+
+    s->hits++;
+    if (het68_time_synced()) {
+        uint32_t now = het68_time_epoch_sec();
+        if (!s->first_seen) s->first_seen = now;
+        s->last_seen = now;
+    }
+
+    recount();
+    if (is_new || time_offer || has_location || (s->hits % 8u) == 0u)
+        g_dirty = true;
+}
+
+void drone_store_poll(bool usb_audio_idle) {
+    if (!usb_audio_idle) return;
+
+    if (g_phase == SAVE_IDLE) {
+        if (!g_dirty) return;
+        build_stage_blob();
+        g_save_slot = 1u - g_active_slot;
+        g_prog_off = 0;
+        g_phase = SAVE_ERASE;
+    }
+
+    if (g_phase == SAVE_ERASE) {
+        flash_op_t op = {
+            .off = (g_save_slot == 0u) ? DRONE_SLOT0_OFF : DRONE_SLOT1_OFF,
+            .len = FLASH_SECTOR_SIZE
+        };
+        int rc = flash_safe_execute(flash_erase_cb, &op, 200);
+        if (rc != PICO_OK) return;
+        g_phase = SAVE_PROG;
+        g_prog_off = 0;
+        return;
+    }
+
+    if (g_phase == SAVE_PROG) {
+        uint32_t base = (g_save_slot == 0u) ? DRONE_SLOT0_OFF : DRONE_SLOT1_OFF;
+        uint32_t need = (sizeof(drone_blob_t) + FLASH_PAGE_SIZE - 1u) &
+                        ~(FLASH_PAGE_SIZE - 1u);
+        if (g_prog_off >= need) {
+            drone_blob_t *b = (drone_blob_t *)g_stage;
+            g_seq = b->seq;
+            g_active_slot = g_save_slot;
+            g_dirty = false;
+            g_phase = SAVE_IDLE;
+            uint32_t lock = dbg_line_lock();
+            dbg_puts("FLASH: DRONE ACID commit seq=");
+            dbg_putu32(g_seq);
+            dbg_puts(" slot=");
+            dbg_putu32(g_active_slot);
+            dbg_puts(" n=");
+            dbg_putu32(g_count);
+            dbg_putc('\n');
+            dbg_line_unlock(lock);
+            return;
+        }
+        flash_prog_t op = {
+            .flash_off = base + g_prog_off,
+            .stage_off = g_prog_off,
+            .len = FLASH_PAGE_SIZE
+        };
+        int rc = flash_safe_execute(flash_prog_page_cb, &op, 200);
+        if (rc != PICO_OK) return;
+        g_prog_off += FLASH_PAGE_SIZE;
+    }
+}
+
+static void dump_one(const drone_slot_t *s) {
+    dbg_puts("DRONE id=");
+    // synthetic stable-ish id: first 3 MAC bytes + hits not needed; use index via uas
+    dbg_puts(s->uas_id[0] ? s->uas_id : "(no-id)");
+    dbg_puts(" mac=");
+    put_mac(s->addr);
+    dbg_puts(" rssi=");
+    put_i32(s->rssi);
+    dbg_puts(" q=");
+    dbg_putu32(s->quality);
+    dbg_puts(" hits=");
+    dbg_putu32(s->hits);
+    dbg_puts(" time_offers=");
+    dbg_putu32(s->time_offers);
+    if (s->flags & DRONE_FLAG_LOCATION) {
+        dbg_puts(" lat=");
+        put_i32(s->lat_e7);
+        dbg_puts(" lon=");
+        put_i32(s->lon_e7);
+        dbg_puts(" alt_m=");
+        put_i32(s->alt_geoid_m);
+    }
+    if (s->first_seen || s->last_seen) {
+        dbg_puts(" first=");
+        dbg_putu32(s->first_seen);
+        dbg_puts(" last=");
+        dbg_putu32(s->last_seen);
+    }
+    dbg_puts(" ua_type=");
+    dbg_putu32(s->ua_type);
+    dbg_putc('\n');
+}
+
+void drone_store_stats_uart(void) {
+    dbg_puts("DRONE store n=");
+    dbg_putu32(g_count);
+    dbg_puts(" seq=");
+    dbg_putu32(g_seq);
+    dbg_puts(" flash_slot=");
+    dbg_putu32(g_active_slot);
+    if (g_dirty) dbg_puts(" dirty");
+    if (g_phase != SAVE_IDLE) dbg_puts(" saving");
+    dbg_putc('\n');
+}
+
+void drone_store_list_uart(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("=== known drones (flash");
+    if (g_dirty) dbg_puts("+dirty");
+    dbg_puts(") ===\n");
+    drone_store_stats_uart();
+    if (g_count == 0) dbg_puts("(empty)\n");
+    for (uint32_t i = 0; i < DRONE_STORE_MAX; i++) {
+        if (!g_slots[i].used) continue;
+        dump_one(&g_slots[i]);
+    }
+    dbg_puts("=== end known drones ===\n");
+    dbg_line_unlock(lock);
+}
+
+bool drone_store_clear(void) {
+    if (g_phase != SAVE_IDLE) return false;
+    memset(g_slots, 0, sizeof(g_slots));
+    g_count = 0;
+    g_next_id = 1;
+    g_dirty = true;
+    return true;
+}

--- a/drone_store.h
+++ b/drone_store.h
@@ -1,0 +1,70 @@
+// drone_store.h — flash-backed registry of known OpenDroneID drones.
+//
+// Flash: ACID dual-slot in sectors [-8,-7] (below BTstack TLV / DET / ENT).
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#define DRONE_STORE_MAX   16
+#define DRONE_UAS_ID_LEN  21  // 20 chars + NUL
+
+typedef struct {
+    uint32_t used;
+    uint8_t  addr[6];
+    int8_t   rssi;
+    uint8_t  id_type;
+    uint8_t  ua_type;
+    uint8_t  flags;          // bit0 has_basic, bit1 has_location
+    uint8_t  quality;        // last RSSI-derived quality 0..100
+    char     uas_id[DRONE_UAS_ID_LEN];
+    uint8_t  _pad0;
+    int32_t  lat_e7;
+    int32_t  lon_e7;
+    int16_t  alt_geoid_m;
+    uint16_t speed_cm_s;
+    uint16_t heading_deg;
+    uint16_t _pad1;
+    uint32_t first_seen;     // unix epoch (0 if never synced when seen)
+    uint32_t last_seen;      // unix epoch
+    uint32_t hits;
+    uint32_t time_offers;    // System messages that offered wall-clock
+} drone_slot_t;
+
+typedef struct {
+    uint32_t magic;
+    uint32_t version;
+    uint32_t seq;
+    uint32_t next_id;
+    uint32_t count;
+    uint32_t crc;
+    uint32_t reserved[2];
+    drone_slot_t slots[DRONE_STORE_MAX];
+} drone_blob_t;
+
+void drone_store_core_init(void);
+void drone_store_init(void);
+void drone_store_poll(bool usb_audio_idle);
+
+bool drone_store_dirty(void);
+bool drone_store_saving(void);
+
+uint32_t drone_store_count(void);
+uint32_t drone_store_seq(void);
+const drone_slot_t *drone_store_slot(uint32_t index);
+
+// Upsert by BLE MAC (preferred) or UAS ID. RAM only — flash via poll().
+void drone_store_observe(const uint8_t addr[6], int8_t rssi,
+                         const char *uas_id, uint8_t id_type, uint8_t ua_type,
+                         bool has_basic, bool has_location,
+                         int32_t lat_e7, int32_t lon_e7, int16_t alt_geoid_m,
+                         uint16_t speed_cm_s, uint16_t heading_deg,
+                         bool time_offer);
+
+void drone_store_list_uart(void);
+void drone_store_stats_uart(void);
+
+bool drone_store_clear(void);
+uint32_t drone_blob_crc(const drone_blob_t *b);
+
+// Map RSSI (dBm) → quality 0..100 for time / drone metadata.
+uint8_t drone_rssi_quality(int8_t rssi);

--- a/het68_time.c
+++ b/het68_time.c
@@ -1,4 +1,4 @@
-// het68_time.c — epoch clock anchored by UART TIME SYNC (or RID System time).
+// het68_time.c — epoch clock anchored by UART TIME SYNC or RID System time.
 #include "het68_time.h"
 #include "debug_io.h"
 #include "remote_id.h"
@@ -8,21 +8,34 @@ static bool g_synced;
 static uint32_t g_epoch0;           // unix seconds at sync instant
 static absolute_time_t g_at0;       // pico time at sync instant
 static uint32_t g_synced_at_epoch;  // copy of g_epoch0 for status
+static het68_time_src_t g_source;
+static uint8_t g_quality_base;
 
 void het68_time_init(void) {
     g_synced = false;
     g_epoch0 = 0;
     g_synced_at_epoch = 0;
+    g_source = HET68_TIME_SRC_NONE;
+    g_quality_base = 0;
     g_at0 = get_absolute_time();
 }
 
-bool het68_time_sync(uint32_t unix_epoch_sec) {
+bool het68_time_sync_from(uint32_t unix_epoch_sec, het68_time_src_t src,
+                          uint8_t quality) {
     if (unix_epoch_sec < 1700000000u) return false; // reject nonsense / year < 2023
+    if (src == HET68_TIME_SRC_NONE) return false;
+    if (quality > 100u) quality = 100u;
     g_epoch0 = unix_epoch_sec;
     g_synced_at_epoch = unix_epoch_sec;
     g_at0 = get_absolute_time();
     g_synced = true;
+    g_source = src;
+    g_quality_base = quality;
     return true;
+}
+
+bool het68_time_sync(uint32_t unix_epoch_sec) {
+    return het68_time_sync_from(unix_epoch_sec, HET68_TIME_SRC_UART, 100u);
 }
 
 bool het68_time_synced(void) { return g_synced; }
@@ -43,10 +56,73 @@ uint32_t het68_time_epoch_ms(void) {
 
 uint32_t het68_time_synced_at(void) { return g_synced_at_epoch; }
 
+het68_time_src_t het68_time_source(void) {
+    return g_synced ? g_source : HET68_TIME_SRC_NONE;
+}
+
+const char *het68_time_source_name(het68_time_src_t src) {
+    switch (src) {
+        case HET68_TIME_SRC_UART: return "uart";
+        case HET68_TIME_SRC_RID:  return "rid";
+        default:                  return "none";
+    }
+}
+
+uint32_t het68_time_age_sec(void) {
+    if (!g_synced) return 0;
+    int64_t us = absolute_time_diff_us(g_at0, get_absolute_time());
+    if (us < 0) us = 0;
+    return (uint32_t)(us / 1000000);
+}
+
+uint8_t het68_time_quality_base(void) {
+    return g_synced ? g_quality_base : 0;
+}
+
+uint8_t het68_time_quality(void) {
+    if (!g_synced) return 0;
+    uint32_t age = het68_time_age_sec();
+    uint32_t decay = age / 60u; // ~1 point per minute
+    if (decay >= (uint32_t)g_quality_base) return 1u;
+    return (uint8_t)(g_quality_base - (uint8_t)decay);
+}
+
 void het68_time_dump_uart(void) {
     uint32_t lock = dbg_line_lock();
     dbg_puts("TIME synced=");
     dbg_puts(g_synced ? "1" : "0");
+    dbg_puts(" source=");
+    dbg_puts(het68_time_source_name(het68_time_source()));
+    dbg_puts(" epoch=");
+    dbg_putu32(het68_time_epoch_sec());
+    dbg_puts(" synced_at=");
+    dbg_putu32(g_synced_at_epoch);
+    dbg_puts(" age_s=");
+    dbg_putu32(het68_time_age_sec());
+    dbg_puts(" quality=");
+    dbg_putu32(het68_time_quality());
+    if (remote_id_available()) {
+        dbg_puts(" rid_unix=");
+        dbg_putu32(remote_id_last_unix());
+        dbg_puts(" rid_syncs=");
+        dbg_putu32(remote_id_time_sync_count());
+    }
+    dbg_putc('\n');
+    dbg_line_unlock(lock);
+}
+
+void het68_time_info_uart(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("TIME INFO synced=");
+    dbg_puts(g_synced ? "1" : "0");
+    dbg_puts(" source=");
+    dbg_puts(het68_time_source_name(het68_time_source()));
+    dbg_puts(" age_s=");
+    dbg_putu32(het68_time_age_sec());
+    dbg_puts(" quality=");
+    dbg_putu32(het68_time_quality());
+    dbg_puts(" quality_base=");
+    dbg_putu32(het68_time_quality_base());
     dbg_puts(" epoch=");
     dbg_putu32(het68_time_epoch_sec());
     dbg_puts(" synced_at=");

--- a/het68_time.h
+++ b/het68_time.h
@@ -1,16 +1,39 @@
-// het68_time.h — wall-clock time synced over UART (required for DET timestamps).
+// het68_time.h — wall-clock time synced over UART or OpenDroneID RID.
 #pragma once
 #include <stdint.h>
 #include <stdbool.h>
 
+typedef enum {
+    HET68_TIME_SRC_NONE = 0,
+    HET68_TIME_SRC_UART = 1,
+    HET68_TIME_SRC_RID  = 2,
+} het68_time_src_t;
+
 void het68_time_init(void);
 
-// TIME SYNC <unix_epoch_seconds>
+// TIME SYNC <unix_epoch_seconds> — treated as UART source, quality 100.
 bool het68_time_sync(uint32_t unix_epoch_sec);
+
+// Sync with explicit source + base quality (0..100).
+bool het68_time_sync_from(uint32_t unix_epoch_sec, het68_time_src_t src,
+                          uint8_t quality);
 
 bool het68_time_synced(void);
 uint32_t het68_time_epoch_sec(void);   // 0 if not synced
 uint32_t het68_time_epoch_ms(void);    // 0 if not synced
 uint32_t het68_time_synced_at(void);   // epoch when SYNC was applied (0 if never)
 
-void het68_time_dump_uart(void);
+het68_time_src_t het68_time_source(void);
+const char *het68_time_source_name(het68_time_src_t src);
+
+// Seconds since last successful sync (0 if never synced).
+uint32_t het68_time_age_sec(void);
+
+// Effective quality 0..100: base quality decayed by age (~1 point / 60 s).
+uint8_t het68_time_quality(void);
+
+// Base quality from the last sync (before age decay).
+uint8_t het68_time_quality_base(void);
+
+void het68_time_dump_uart(void);       // compact TIME line
+void het68_time_info_uart(void);       // TIME INFO: source / age / quality

--- a/main.c
+++ b/main.c
@@ -33,6 +33,13 @@
 #include "drone_store.h"
 #include "dps310.h"
 #include "cli.h"
+
+// Apply baro-derived speed of sound to DOA when a fresh sample exists.
+static void baro_update_sound_speed(void) {
+    float c = dps310_speed_of_sound_m_s();
+    if (c > 0.0f)
+        doa_set_c_sound_m_s(c);
+}
 #include "core1_launch.h"
 #include "i2s_rx.pio.h"
 #include "i2s_clk.pio.h"
@@ -857,7 +864,15 @@ int main(void)
         dbg_puts("RID: skipped (board has no Wi-Fi/BT)\n");
 
     // Optional Grove DPS310 on free I2C1 pins GP2 (SDA) / GP3 (SCL).
-    (void)dps310_init();
+    if (dps310_init()) {
+        // A few polls so STATUS/boot can show c=… before the main loop.
+        for (int i = 0; i < 8; i++) {
+            sleep_ms(20);
+            dps310_poll();
+            baro_update_sound_speed();
+            if (dps310_speed_of_sound_m_s() > 0.0f) break;
+        }
+    }
 
     // Boot dump: all persisted data + statistics (same as UART STATUS).
     cli_print_status();
@@ -906,6 +921,7 @@ int main(void)
 
         remote_id_poll();
         dps310_poll();
+        baro_update_sound_speed();
 #endif
         // Audio frames are produced in tud_audio_tx_done_pre_load_cb(), driven by
         // the USB IN cadence — nothing to pump from the main loop here.

--- a/main.c
+++ b/main.c
@@ -6,6 +6,7 @@
 //   GP26/27/28 = SD mics 4–6 (Grove A0/A1/A2 pin 1); SEL hardwired GND on modules
 //   GP0 = UART TX, GP1 = UART RX (Grove UART0 → Debug Probe)
 //   GP6/GP7 = piezo H-bridge (Grove I2C1)
+//   GP2/GP3 = Grove DPS310 barometer I2C1 SDA/SCL (optional; skipped if absent)
 //
 // HET68_USB_DIAG=1 bypasses I2S and sends a simulated 1 kHz tone (bench test).
 
@@ -30,6 +31,7 @@
 #include "detection_log.h"
 #include "het68_time.h"
 #include "drone_store.h"
+#include "dps310.h"
 #include "cli.h"
 #include "core1_launch.h"
 #include "i2s_rx.pio.h"
@@ -753,6 +755,16 @@ static void dbg_heartbeat(uint32_t hb_count)
         }
         if (!het68_time_synced()) dbg_puts(" time=unsynced");
         else dbg_puts(" time=ok");
+        if (dps310_available()) {
+            dbg_puts(" baro=");
+            // one decimal hPa via integer tenths
+            int32_t t = (int32_t)(dps310_pressure_hpa() * 10.0f);
+            if (t < 0) { dbg_putc('-'); t = -t; }
+            dbg_putu32((uint32_t)(t / 10));
+            dbg_putc('.');
+            dbg_putu32((uint32_t)(t % 10));
+            dbg_puts("hPa");
+        }
         if (entity_store_dirty() || detection_log_dirty() || drone_store_dirty())
             dbg_puts(" flash=dirty");
         if (entity_store_saving() || detection_log_saving() || drone_store_saving())
@@ -844,6 +856,9 @@ int main(void)
     else
         dbg_puts("RID: skipped (board has no Wi-Fi/BT)\n");
 
+    // Optional Grove DPS310 on free I2C1 pins GP2 (SDA) / GP3 (SCL).
+    (void)dps310_init();
+
     // Boot dump: all persisted data + statistics (same as UART STATUS).
     cli_print_status();
     cli_print_help();
@@ -890,6 +905,7 @@ int main(void)
         }
 
         remote_id_poll();
+        dps310_poll();
 #endif
         // Audio frames are produced in tud_audio_tx_done_pre_load_cb(), driven by
         // the USB IN cadence — nothing to pump from the main loop here.

--- a/main.c
+++ b/main.c
@@ -29,6 +29,7 @@
 #include "entity_store.h"
 #include "detection_log.h"
 #include "het68_time.h"
+#include "drone_store.h"
 #include "cli.h"
 #include "core1_launch.h"
 #include "i2s_rx.pio.h"
@@ -752,8 +753,10 @@ static void dbg_heartbeat(uint32_t hb_count)
         }
         if (!het68_time_synced()) dbg_puts(" time=unsynced");
         else dbg_puts(" time=ok");
-        if (entity_store_dirty() || detection_log_dirty()) dbg_puts(" flash=dirty");
-        if (entity_store_saving() || detection_log_saving()) dbg_puts(" flash=saving");
+        if (entity_store_dirty() || detection_log_dirty() || drone_store_dirty())
+            dbg_puts(" flash=dirty");
+        if (entity_store_saving() || detection_log_saving() || drone_store_saving())
+            dbg_puts(" flash=saving");
         if (!dbg_log_enabled()) dbg_puts(" log=off");
     }
 #endif
@@ -821,14 +824,13 @@ int main(void)
     het68_time_init();
     cli_init();
 
-    // Flash-backed entity gallery + detection log (ACID dual-slot each).
+    // Flash-backed entity gallery + detection log + known drones (ACID dual-slot each).
     entity_store_core_init();
     entity_store_init();
     detection_log_core_init();
     detection_log_init();
-    entity_store_dump_uart();
-    detection_log_list_uart();
-    cli_print_help();
+    drone_store_core_init();
+    drone_store_init();
 
     // Direction-of-arrival on core1 (het68_launch_core1 resets core1 after SWD flash).
     doa_start();
@@ -841,6 +843,10 @@ int main(void)
         dbg_puts("RID: init failed\n");
     else
         dbg_puts("RID: skipped (board has no Wi-Fi/BT)\n");
+
+    // Boot dump: all persisted data + statistics (same as UART STATUS).
+    cli_print_status();
+    cli_print_help();
 #endif
 
     // Heartbeat LED. Boards whose LED is on a wireless module (e.g. Pico W /
@@ -868,12 +874,14 @@ int main(void)
         }
 
         // Opportunistic ACID flash: only when USB audio streaming is idle (alt=0).
-        // Never run both flash state machines in the same poll (one erase/page max).
+        // At most one flash store advances per poll (one erase/page max).
         bool usb_idle = (dbg_last_alt == 0u);
-        if (!detection_log_saving())
+        if (!detection_log_saving() && !drone_store_saving())
             entity_store_poll(usb_idle);
-        if (!entity_store_saving())
+        if (!entity_store_saving() && !drone_store_saving())
             detection_log_poll(usb_idle);
+        if (!entity_store_saving() && !detection_log_saving())
+            drone_store_poll(usb_idle);
 
         while (dbg_rx_available()) {
             int ch = dbg_getc();

--- a/remote_id.c
+++ b/remote_id.c
@@ -5,6 +5,7 @@
 #include "remote_id.h"
 #include "debug_io.h"
 #include "detection_log.h"
+#include "drone_store.h"
 #include "het68_time.h"
 #include "pico/stdlib.h"
 #include <string.h>
@@ -54,6 +55,7 @@ static volatile bool g_scan_on;
 static uint32_t g_last_log_ms;
 static volatile uint32_t g_pending_unix;
 static volatile bool g_pending_sync;
+static volatile int8_t g_pending_rssi;
 static uint32_t g_last_unix;
 static uint32_t g_time_sync_count;
 static uint32_t g_last_rid_sync_ms;
@@ -130,20 +132,21 @@ static void parse_location(rid_track_t *t, const uint8_t *m) {
 
 // Offer wall-clock from ODID System timestamp (seconds since 2019-01-01 UTC).
 // Applied later on the main loop — never call het68_time_sync from HCI callback.
-static void offer_odid_system_time(uint32_t odid_ts_2019) {
+static void offer_odid_system_time(uint32_t odid_ts_2019, int8_t rssi) {
     if (odid_ts_2019 == 0u) return;
     uint64_t unix64 = (uint64_t)odid_ts_2019 + (uint64_t)RID_ODID_EPOCH_UNIX;
     if (unix64 < 1700000000ull) return;          // before het68_time floor
     if (unix64 > 2200000000ull) return;          // reject absurd future
     g_pending_unix = (uint32_t)unix64;
     g_last_unix = (uint32_t)unix64;
+    g_pending_rssi = rssi;
     g_pending_sync = true;
 }
 
 static void parse_system(rid_track_t *t, const uint8_t *m) {
     // System message (type 4): Operator Lat/Lon + Timestamp @ bytes 20..23 (LE).
-    (void)t;
-    offer_odid_system_time(rd_u32_le(&m[20]));
+    t->sys_pending = 1;
+    offer_odid_system_time(rd_u32_le(&m[20]), t->rssi);
 }
 
 static void parse_odid_message(rid_track_t *t, const uint8_t *m) {
@@ -347,14 +350,33 @@ void remote_id_poll(void) {
     uint32_t now = to_ms_since_boot(get_absolute_time());
     for (int i = 0; i < RID_MAX_TRACKS; i++) {
         if (!g_tracks[i].used) continue;
-        if ((now - g_tracks[i].last_ms) > RID_STALE_MS)
+        if ((now - g_tracks[i].last_ms) > RID_STALE_MS) {
             g_tracks[i].used = 0;
+            continue;
+        }
+
+        // Persist known drones when the live track updates (not every poll).
+        rid_track_t *t = &g_tracks[i];
+        bool time_offer = t->sys_pending != 0;
+        t->sys_pending = 0;
+        if ((t->has_basic || t->has_location) &&
+            (time_offer || t->last_ms != t->flash_ms)) {
+            drone_store_observe(t->addr, t->rssi,
+                                t->uas_id, t->id_type, t->ua_type,
+                                t->has_basic != 0, t->has_location != 0,
+                                t->lat_e7, t->lon_e7, t->alt_geoid_m,
+                                t->speed_cm_s, t->heading_deg,
+                                time_offer);
+            t->flash_ms = t->last_ms;
+        }
     }
 
     // Apply pending wall-clock from System message (main loop, not HCI).
     if (g_pending_sync) {
         g_pending_sync = false;
         uint32_t unix = g_pending_unix;
+        int8_t rssi = g_pending_rssi;
+        uint8_t q = drone_rssi_quality(rssi);
         bool apply = !het68_time_synced();
         if (!apply) {
             uint32_t cur = het68_time_epoch_sec();
@@ -366,12 +388,14 @@ void remote_id_poll(void) {
         if (apply &&
             (het68_time_synced() ? ((now - g_last_rid_sync_ms) >= RID_TIME_MIN_GAP_MS)
                                  : true)) {
-            if (het68_time_sync(unix)) {
+            if (het68_time_sync_from(unix, HET68_TIME_SRC_RID, q)) {
                 g_last_rid_sync_ms = now;
                 g_time_sync_count++;
                 uint32_t lock = dbg_line_lock();
                 dbg_puts("TIME SYNC via RID epoch=");
                 dbg_putu32(unix);
+                dbg_puts(" quality=");
+                dbg_putu32(q);
                 dbg_puts(" (OpenDroneID System)\n");
                 dbg_line_unlock(lock);
             }

--- a/remote_id.h
+++ b/remote_id.h
@@ -23,6 +23,8 @@ typedef struct {
     uint16_t speed_cm_s;    // horizontal, approx cm/s
     uint16_t heading_deg;   // 0..359, 361 = unknown
     uint32_t last_ms;
+    uint32_t flash_ms;      // last_ms already persisted to drone_store
+    uint8_t  sys_pending;   // System msg seen since last main-loop observe
 } rid_track_t;
 
 // Returns true if BT RID is compiled in and init succeeded.

--- a/wiring_and_bom.md
+++ b/wiring_and_bom.md
@@ -151,11 +151,28 @@ No series resistor; keep leads short.
 
 ---
 
-## Planned peripherals (I2C on headers)
+## Barometer — Grove DPS310 on **GP2 / GP3** (I2C1)
 
-Future sensors on free header pins (e.g. GP2/GP3 as I2C1):
+Optional **Seeed Grove High Precision Barometric Pressure Sensor DPS310**
+(product **101020812**, Infineon DPS310). Firmware claims these pins only when
+they are free and a device ACKs at I2C `0x77` (default) or `0x76` (pad short).
 
-- BME280 — temperature, pressure, humidity
+**Do not** plug this module into Grove Shield **I2C0** (GP8/GP9 = mic clocks) or
+**I2C1** (GP6/GP7 = piezo). Wire the Grove cable to the free Pico header pins:
+
+| Grove wire | Colour | Pico pin | Function |
+|---|---|---|---|
+| 1 | **white** | **GP2** | I2C1 **SDA** |
+| 2 | **yellow** | **GP3** | I2C1 **SCL** |
+| 3 | **red** | **3V3** | power (shield 3.3 V) |
+| 4 | **black** | **GND** | ground |
+
+Range: pressure **300–1200 hPa**, temperature **−40–85 °C**, pressure precision
+±0.002 hPa. UART: `BARO` (also in `STATUS` / boot dump / heartbeat `baro=`).
+Wiki: https://wiki.seeedstudio.com/Grove-High-Precision-Barometric-Pressure-Sensor-DPS310/
+
+### Still free / planned on other headers
+
 - INA219 — single-channel current/voltage
 - INA3221 — three-channel current/voltage
 
@@ -168,6 +185,7 @@ Future sensors on free header pins (e.g. GP2/GP3 as I2C1):
 | Raspberry Pi Pico 2 (RP2350) | 1 |
 | Grove Shield for Pi Pico v1.0 | 1 |
 | ICS-43434 breakout / mic module | 6 |
-| Grove cable 4-pin | 8+ (2 clock branches + 6 data) |
+| Grove cable 4-pin | 8+ (2 clock branches + 6 data) + 1 for DPS310 |
+| Grove DPS310 barometer (Seeed 101020812) | 1 (optional) |
 | PS1240 passive piezo | 1 |
 | Raspberry Pi Debug Probe | 1 |

--- a/wiring_and_bom.md
+++ b/wiring_and_bom.md
@@ -169,6 +169,9 @@ they are free and a device ACKs at I2C `0x77` (default) or `0x76` (pad short).
 
 Range: pressure **300–1200 hPa**, temperature **−40–85 °C**, pressure precision
 ±0.002 hPa. UART: `BARO` (also in `STATUS` / boot dump / heartbeat `baro=`).
+From temperature the firmware computes dry-air **speed of sound**
+`c = 331.3√(1+T/273.15)` — shown as `SOUND c=…` / `BARO … c=…m/s` and used
+by DOA TDOA when the sensor is present (else 343 m/s).
 Wiki: https://wiki.seeedstudio.com/Grove-High-Precision-Barometric-Pressure-Sensor-DPS310/
 
 ### Still free / planned on other headers


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- From DPS310 **temperature**, compute dry-air speed of sound:
  `c = 331.3 * sqrt(1 + T°C/273.15)` (no humidity on this sensor).
- Show **`SOUND c=…m/s src=baro|default`** in CLI `STATUS` stats; `BARO` line also includes `c=…m/s`.
- Feed runtime `c` into **DOA TDOA** (`doa_set_c_sound_m_s`); without sensor keep **343 m/s**.
- Size DOA lag buffers for cold extreme (~300 m/s) so baro correction stays in range.
- Version **1.2.2**.

## What the barometer measures / where it appears
| Quantity | Where |
|---|---|
| Pressure (hPa) | `BARO`, `STATUS`, heartbeat `baro=` |
| Temperature (°C) | `BARO`, `STATUS` |
| Altitude (rough, QNH 1013.25) | `BARO`, `STATUS` |
| Speed of sound (from T) | `SOUND` in STATUS stats, `BARO c=`, DOA TDOA |

## Test plan
- [x] `./build.sh` (pico2)
- [x] Plus 2 W build
- [ ] No sensor: `STATUS` shows `SOUND c=343.0m/s src=default`
- [ ] With DPS310: `SOUND … src=baro` and `BARO … c=…m/s` track temperature

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

