### PR TITLE
1.2.3: Cramer/NPL moist-air speed of sound

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 # Build firmware on a GitHub Release whose tag is semver core (semver.org):
 #   x.y.z   or   vx.y.z
 # Uploads UF2 + ELF as release assets (pico2 + Plus 2 W when applicable).
+# After a successful build, force-moves the floating git tag `latest` to that
+# commit and marks the GitHub Release as the repo "Latest" release.
 name: Release firmware
 
 on:
@@ -21,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Validate semver tag (x.y.z or vx.y.z)
         id: semver

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,9 +105,24 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.semver.outputs.tag }}
+          make_latest: true
           files: |
             dist/het68-${{ steps.semver.outputs.version }}-pico2.uf2
             dist/het68-${{ steps.semver.outputs.version }}-pico2.elf
             dist/het68-${{ steps.semver.outputs.version }}-pico-plus2-w.uf2
             dist/het68-${{ steps.semver.outputs.version }}-pico-plus2-w.elf
           fail_on_unmatched_files: true
+
+      # Floating pointer for "whatever last built successfully as a semver release".
+      # Not a semver tag — do not create a GitHub Release named "latest".
+      - name: Move floating git tag latest
+        env:
+          TAG: ${{ steps.semver.outputs.tag }}
+        run: |
+          set -Eeuo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Release checkout is the tagged commit; pin latest there after green build.
+          git tag -f latest "${GITHUB_SHA}"
+          git push origin refs/tags/latest --force
+          echo "Moved git tag latest -> ${GITHUB_SHA} (release ${TAG})"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(SRCS
 add_executable(pico_6mic_soundcard ${SRCS})
 
 # Version stamp (UART help / docs). Semver core for releases.
-add_compile_definitions(HET68_VERSION_STR=\"1.2.2\")
+add_compile_definitions(HET68_VERSION_STR=\"1.2.3\")
 
 # PIO header po add_executable
 pico_generate_pio_header(pico_6mic_soundcard ${CMAKE_CURRENT_LIST_DIR}/pio/i2s_rx.pio)

--- a/README.md
+++ b/README.md
@@ -159,10 +159,12 @@ header pins **GP2 (SDA) / GP3 (SCL)** + 3V3/GND — **not** to shield I2C0/I2C1
 (those are mic clocks / piezo). Firmware probes `0x77` then `0x76`; if the pins
 are busy or no device answers, baro is skipped. CLI: `BARO` (aliases `DPS`,
 `PRESSURE`); also in `STATUS`, boot dump, and heartbeat (`baro=…hPa`).
-**v1.2.2:** dry-air speed of sound from temperature
-(`c = 331.3√(1+T/273.15)`) is shown as `SOUND c=…m/s` in `STATUS` stats /
-`BARO`, and fed into DOA TDOA (default 343 m/s when baro absent).
-Details: [`wiring_and_bom.md`](wiring_and_bom.md),
+**v1.2.3:** moist-air speed of sound (Cramer/NPL-style) from DPS310 **T+P**
+and assumed **RH** (default 50 %, set with `BARO RH <0-100>`):
+Arden-Buck \(p_{sat}\), \(x_w=RH\cdot p_{sat}/p\), then
+\(c=331.36\sqrt{T_K/273.15}\,(1+0.314 x_w+0.037 x_w^2)\).
+Shown as `SOUND c=…` / `BARO … c=…`; fed into DOA TDOA (default 343 m/s
+without baro). Details: [`wiring_and_bom.md`](wiring_and_bom.md),
 [Seeed wiki](https://wiki.seeedstudio.com/Grove-High-Precision-Barometric-Pressure-Sensor-DPS310/).
 
 BOM and module layout: `wiring_and_bom.md`.

--- a/cli.c
+++ b/cli.c
@@ -43,6 +43,7 @@ void cli_print_help(void) {
     dbg_puts("DRONE LIST           — known drones persisted in flash\n");
     dbg_puts("DRONE CLEAR          — erase known-drone flash registry\n");
     dbg_puts("BARO                 — Grove DPS310 pressure/temperature (GP2/GP3)\n");
+    dbg_puts("BARO RH <0-100>      — assumed RH percent for sound speed (default 50)\n");
     dbg_puts("RID LIST             — OpenDroneID BLE tracks (CYW43 boards)\n");
     dbg_puts("RID ON | RID OFF     — enable/disable BLE Remote ID scan\n");
     dbg_puts("Note: DET timestamps after TIME SYNC (UART or RID System msg).\n");
@@ -93,14 +94,22 @@ void cli_print_status(void) {
         bool from_baro = (c > 0.0f);
         if (!from_baro) c = doa_c_sound_m_s();
         dbg_puts("SOUND c=");
-        // one decimal m/s
-        int32_t t = (int32_t)(c * 10.0f + (c >= 0.0f ? 0.5f : -0.5f));
+        // two decimals m/s (Cramer/NPL target precision)
+        int32_t t = (int32_t)(c * 100.0f + (c >= 0.0f ? 0.5f : -0.5f));
         if (t < 0) { dbg_putc('-'); t = -t; }
-        dbg_putu32((uint32_t)(t / 10));
+        dbg_putu32((uint32_t)(t / 100));
         dbg_putc('.');
-        dbg_putu32((uint32_t)(t % 10));
+        uint32_t frac = (uint32_t)(t % 100);
+        if (frac < 10u) dbg_putc('0');
+        dbg_putu32(frac);
         dbg_puts("m/s src=");
-        dbg_puts(from_baro ? "baro" : "default");
+        dbg_puts(from_baro ? "cramer" : "default");
+        if (from_baro) {
+            dbg_puts(" RH=");
+            int32_t rh = (int32_t)(dps310_rh() * 100.0f + 0.5f);
+            dbg_putu32((uint32_t)rh);
+            dbg_puts("%");
+        }
         dbg_putc('\n');
     }
     dbg_line_unlock(lock);
@@ -284,6 +293,27 @@ static void handle_line(char *line) {
         strcmp(line, "PRESSURE") == 0) {
         dps310_poll();
         dps310_dump_uart();
+        return;
+    }
+    if (strncmp(line, "BARO RH ", 8) == 0) {
+        uint32_t pct = parse_u32(line + 8);
+        if (pct > 100u) {
+            dbg_puts("BARO RH ERR: need 0..100\n");
+        } else {
+            dps310_set_rh((float)pct / 100.0f);
+            dbg_puts("BARO RH=");
+            dbg_putu32(pct);
+            dbg_puts("% (assumed; used for SOUND/DOA)\n");
+            // Refresh DOA c immediately if baro sample exists.
+            float c = dps310_speed_of_sound_m_s();
+            if (c > 0.0f) doa_set_c_sound_m_s(c);
+        }
+        return;
+    }
+    if (strcmp(line, "BARO RH") == 0) {
+        dbg_puts("BARO RH=");
+        dbg_putu32((uint32_t)(dps310_rh() * 100.0f + 0.5f));
+        dbg_puts("%\n");
         return;
     }
 

--- a/dps310.c
+++ b/dps310.c
@@ -51,6 +51,8 @@ static float g_pressure_pa;
 static float g_temperature_c;
 static uint32_t g_sample_ms;
 static bool g_have_sample;
+// Assumed RH (0..1) until a humidity sensor is added — default 50 %.
+static float g_rh = 0.50f;
 
 static int32_t twos_complement(uint32_t raw, uint8_t bits) {
     uint32_t sign = 1u << (bits - 1u);
@@ -268,14 +270,38 @@ float dps310_altitude_m(void) {
     return 44330.0f * (1.0f - powf(ratio, 0.19029495f));
 }
 
+void dps310_set_rh(float rh_frac) {
+    if (rh_frac < 0.0f) rh_frac = 0.0f;
+    if (rh_frac > 1.0f) rh_frac = 1.0f;
+    g_rh = rh_frac;
+}
+
+float dps310_rh(void) { return g_rh; }
+
 float dps310_speed_of_sound_m_s(void) {
     if (!g_have_sample) return 0.0f;
-    // Dry air (ISO approximation): c = 331.3 * sqrt(T_K / 273.15).
-    // DPS310 has no humidity; moist air would be slightly faster.
-    float tk = g_temperature_c + 273.15f;
-    if (tk < 233.15f) tk = 233.15f; // clamp ~-40 °C
-    if (tk > 358.15f) tk = 358.15f; // clamp ~+85 °C
-    return 331.3f * sqrtf(tk / 273.15f);
+
+    float T = g_temperature_c;
+    float p = g_pressure_pa;
+    // DPS310 operating window; reject nonsense before Arden-Buck / x_w.
+    if (T < -40.0f) T = -40.0f;
+    if (T > 85.0f) T = 85.0f;
+    if (p < 30000.0f || p > 120000.0f) return 0.0f;
+
+    // Step 1: Arden-Buck saturation vapour pressure (Pa), T in °C.
+    float psat = 611.21f * expf((18.678f - T / 234.5f) * (T / (235.7f + T)));
+
+    // Step 2: water-vapour mole fraction using DPS310 absolute pressure.
+    float pv = g_rh * psat;
+    float xw = pv / p;
+    if (xw < 0.0f) xw = 0.0f;
+    if (xw > 0.15f) xw = 0.15f; // physical sanity cap
+
+    // Step 3: Cramer / NPL-style moist-air speed (CO2 ~420 ppm baseline 331.36).
+    float tk = T + 273.15f;
+    float c_dry = 331.36f * sqrtf(tk / 273.15f);
+    float humid = 1.0f + 0.314f * xw + 0.037f * xw * xw;
+    return c_dry * humid;
 }
 
 static void put_f1(float v) {
@@ -285,6 +311,17 @@ static void put_f1(float v) {
     if (fp >= 10u) { ip++; fp = 0u; }
     dbg_putu32(ip);
     dbg_putc('.');
+    dbg_putu32(fp);
+}
+
+static void put_f2(float v) {
+    if (v < 0.0f) { dbg_putc('-'); v = -v; }
+    uint32_t ip = (uint32_t)v;
+    uint32_t fp = (uint32_t)((v - (float)ip) * 100.0f + 0.5f);
+    if (fp >= 100u) { ip++; fp = 0u; }
+    dbg_putu32(ip);
+    dbg_putc('.');
+    if (fp < 10u) dbg_putc('0');
     dbg_putu32(fp);
 }
 
@@ -310,11 +347,13 @@ void dps310_dump_uart(void) {
     put_f1(s.pressure_pa * 0.01f);
     dbg_puts("hPa T=");
     put_f1(s.temperature_c);
-    dbg_puts("C alt=");
+    dbg_puts("C RH=");
+    put_f1(dps310_rh() * 100.0f);
+    dbg_puts("% alt=");
     put_f1(dps310_altitude_m());
     dbg_puts("m c=");
-    put_f1(dps310_speed_of_sound_m_s());
-    dbg_puts("m/s age_ms=");
+    put_f2(dps310_speed_of_sound_m_s());
+    dbg_puts("m/s (Cramer/NPL) age_ms=");
     dbg_putu32(s.age_ms);
     dbg_putc('\n');
     dbg_line_unlock(lock);

--- a/dps310.h
+++ b/dps310.h
@@ -30,8 +30,14 @@ float dps310_pressure_hpa(void);        // 0 if none
 float dps310_temperature_c(void);       // 0 if none
 float dps310_altitude_m(void);          // rough QNH=1013.25 hPa; 0 if none
 
-// Dry-air speed of sound from last temperature sample (m/s), or 0 if none.
-// c = 331.3 * sqrt(1 + T_C/273.15). Pressure alone does not change ideal-gas c.
+// Relative humidity fraction 0..1 used for moist-air c(T,p,RH).
+// DPS310 has no RH sensor — default 0.50; override via dps310_set_rh() / CLI.
+void dps310_set_rh(float rh_frac);
+float dps310_rh(void);
+
+// Moist-air speed of sound (m/s) from T+P (DPS310) and configured RH, or 0 if none.
+// Arden-Buck p_sat → x_w = RH*p_sat/p → Cramer/NPL-style:
+//   c = 331.36 * sqrt(T_K/273.15) * (1 + 0.314*x_w + 0.037*x_w^2)
 float dps310_speed_of_sound_m_s(void);
 
 void dps310_dump_uart(void);

--- a/wiring_and_bom.md
+++ b/wiring_and_bom.md
@@ -169,10 +169,17 @@ they are free and a device ACKs at I2C `0x77` (default) or `0x76` (pad short).
 
 Range: pressure **300–1200 hPa**, temperature **−40–85 °C**, pressure precision
 ±0.002 hPa. UART: `BARO` (also in `STATUS` / boot dump / heartbeat `baro=`).
-From temperature the firmware computes dry-air **speed of sound**
-`c = 331.3√(1+T/273.15)` — shown as `SOUND c=…` / `BARO … c=…m/s` and used
-by DOA TDOA when the sensor is present (else 343 m/s).
-Wiki: https://wiki.seeedstudio.com/Grove-High-Precision-Barometric-Pressure-Sensor-DPS310/
+**Speed of sound (v1.2.3, Cramer/NPL-style):** uses DPS310 temperature and
+pressure plus assumed RH (default 50 %; `BARO RH <0-100>` — no humidity
+sensor on this module):
+
+1. Arden-Buck: \(p_{sat}=611.21\exp\bigl((18.678-T/234.5)\,T/(235.7+T)\bigr)\) [Pa]
+2. \(x_w = (RH\cdot p_{sat}) / p\) with \(p\) from DPS310
+3. \(c = 331.36\sqrt{T_K/273.15}\,(1 + 0.314 x_w + 0.037 x_w^2)\) [m/s]
+
+Shown as `SOUND c=…` / `BARO … c=…m/s`; used by DOA TDOA when present
+(else 343 m/s). Wiki:
+https://wiki.seeedstudio.com/Grove-High-Precision-Barometric-Pressure-Sensor-DPS310/
 
 ### Still free / planned on other headers
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Replace dry-air \(c(T)\) with a **Cramer/NPL-style** moist-air model using DPS310 **temperature + pressure** and assumed **RH** (default 50%):

1. **Arden-Buck** \(p_{sat}\)
2. \(x_w = RH \cdot p_{sat} / p\) (pressure from DPS310)
3. \(c = 331.36 \sqrt{T_K/273.15}\,(1 + 0.314 x_w + 0.037 x_w^2)\)

- CLI: `BARO RH <0-100>` (and `BARO RH` to query)
- `STATUS` / `BARO` show `c` to 0.01 m/s and RH; DOA TDOA uses the result
- Version **1.2.3**

## Test plan
- [x] `./build.sh` (pico2)
- [x] Plus 2 W build
- [ ] With DPS310: `STATUS` shows `SOUND … src=cramer RH=50%`
- [ ] `BARO RH 80` changes `c` upward at warm T

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

