### PR TITLE
1.3.0: Acoustic node link (DSSS-BPSK) on GP6/GP7 piezo + mic RX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,22 @@ set(SRCS
     remote_id.c
     drone_store.c
     dps310.c
+    acoustic_link.c
+    node_store.c
 )
 
 add_executable(pico_6mic_soundcard ${SRCS})
 
 # Version stamp (UART help / docs). Semver core for releases.
-add_compile_definitions(HET68_VERSION_STR=\"1.2.7\")
+add_compile_definitions(HET68_VERSION_STR=\"1.3.0\")
+
+# Optional fixed acoustic-link node id (0..7). Default 0; also settable at
+# runtime via the LINK ID CLI command.
+#   HET68_NODE_ID=3 ./build.sh
+if(DEFINED HET68_NODE_ID)
+    add_compile_definitions(HET68_NODE_ID=${HET68_NODE_ID})
+    message(STATUS "het68: acoustic node id=${HET68_NODE_ID}")
+endif()
 message(STATUS "het68: PICO_BOARD=${PICO_BOARD} platform=${PICO_PLATFORM}")
 
 # PIO header po add_executable
@@ -121,6 +131,8 @@ if (PICO_CYW43_SUPPORTED)
     message(STATUS "het68: CYW43 board — enabling BLE OpenDroneID (HET68_BT_RID)")
     target_compile_definitions(pico_6mic_soundcard PRIVATE
         HET68_BT_RID=1
+        # Acoustic-link Wi-Fi wake can bring up CYW43 STA on these boards.
+        HET68_WIFI_WAKE=1
         # 6 * 4096 — keep expression numeric; FLASH_SECTOR_SIZE is 4096 on RP2
         PICO_FLASH_BANK_TOTAL_SIZE=8192
         PICO_FLASH_BANK_STORAGE_OFFSET=\(PICO_FLASH_SIZE_BYTES-24576\)
@@ -134,7 +146,7 @@ if (PICO_CYW43_SUPPORTED)
         ${CMAKE_CURRENT_LIST_DIR}  # btstack_config.h
     )
 else()
-    target_compile_definitions(pico_6mic_soundcard PRIVATE HET68_BT_RID=0)
+    target_compile_definitions(pico_6mic_soundcard PRIVATE HET68_BT_RID=0 HET68_WIFI_WAKE=0)
 endif()
 
 # core1 stack lives in SCRATCH_X (4 KiB on RP2350); default 2 KiB is enough because

--- a/README.md
+++ b/README.md
@@ -194,7 +194,22 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   UART **CLI** (help on boot / first byte / USB mount): `HELP`, `STATUS`,
   `TIME` / `TIME INFO` / `TIME SYNC`, `LOG ON|OFF`,
   `DET LIST|EXPORT|BACKUP|IMPORT|DEL|CLEAR`, `ENT LIST|EXPORT|IMPORT`,
-  `DRONE LIST|CLEAR`, `BARO`, `RID LIST|ON|OFF`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
+  `DRONE LIST|CLEAR`, `BARO`, `LINK`, `RID LIST|ON|OFF`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
+
+* **Acoustic node link (v1.3.0+).** Nodes talk to each other over the existing
+  GP6/GP7 4 kHz PS1240 piezo using **DSSS-BPSK**: a per-node CDMA code
+  (length-127 Gold family) spreads a fixed frame carrying a **Hamming(7,4) FEC +
+  CRC32** payload, with reserved `key_id`/`nonce`/`encrypted` fields for future
+  AEAD. RX rides on the 6-mic 48 kHz capture (mono mix → matched filter). The
+  link does **single-sided two-way ranging** (mutual distance, using the
+  baro-corrected speed of sound), **coarse time sync** (an unsynced node adopts a
+  synced peer's epoch as `TIME` source `acoustic`), and carries `BEACON` /
+  `DETECT` / `CTRL` frames. `CTRL WIFI_WAKE` requests bringing up Wi-Fi for bulk
+  sync / OTA on CYW43 boards. Collisions are handled by CDMA code separation plus
+  randomized beacon jitter. Stealth is best-effort (spread spectrum + low duty),
+  not true inaudibility, since the PS1240 resonates at 4 kHz. UART: `LINK`,
+  `LINK ID <0-7>`, `LINK BEACON`, `LINK WIFI`. See
+  [`acoustic_link.h`](acoustic_link.h) / [`node_store.h`](node_store.h).
 
 * **OpenDroneID / EU Direct Remote ID (v1.1.0+).** On CYW43 boards
   (`PICO_BOARD=pico_w`, `pico2_w`, `pimoroni_pico_plus2_w_rp2350`, or other Pico W

--- a/acoustic_link.c
+++ b/acoustic_link.c
@@ -1,0 +1,565 @@
+// acoustic_link.c — DSSS-BPSK node link on the GP6/GP7 4 kHz piezo + mic RX.
+// See acoustic_link.h for the layering overview. No malloc; RX runs in bounded
+// chunks from the main loop; TX hands a chip buffer to the buzzer ISR.
+#include "acoustic_link.h"
+#include "buzzer.h"
+#include "node_store.h"
+#include "het68_time.h"
+#include "doa.h"
+#include "debug_io.h"
+#include "pico/stdlib.h"
+#include <math.h>
+#include <string.h>
+
+#ifndef HET68_WIFI_WAKE
+#define HET68_WIFI_WAKE 0
+#endif
+
+// ---------------------------------------------------------------------------
+// Node identity + codes
+// ---------------------------------------------------------------------------
+static uint8_t g_node_id;
+
+static int8_t g_pre_code[ALINK_MAX_NODES][ALINK_PREAMBLE_LEN];   // +1/-1
+static int8_t g_data_code[ALINK_MAX_NODES][ALINK_DATA_SF];       // +1/-1
+
+// Two maximal-length degree-7 LFSRs (a preferred-pair Gold construction):
+//   seqA: x^7 + x^6 + 1   seqB: x^7 + x^3 + 1
+static void build_mseq(uint8_t taps_hi, uint8_t taps_lo, uint8_t out[ALINK_PREAMBLE_LEN]) {
+    uint8_t lfsr = 0x7Fu;
+    for (uint32_t i = 0; i < ALINK_PREAMBLE_LEN; i++) {
+        uint8_t bit = (uint8_t)(((lfsr >> taps_hi) ^ (lfsr >> taps_lo)) & 1u);
+        out[i] = (uint8_t)(lfsr & 1u);
+        lfsr = (uint8_t)(((lfsr << 1) | bit) & 0x7Fu);
+    }
+}
+
+static void build_codes(void) {
+    uint8_t a[ALINK_PREAMBLE_LEN], b[ALINK_PREAMBLE_LEN];
+    build_mseq(6u, 5u, a);   // taps at register bits 6,5  -> x^7+x^6+1
+    build_mseq(6u, 2u, b);   // taps at register bits 6,2  -> x^7+x^3+1
+    for (uint32_t n = 0; n < ALINK_MAX_NODES; n++) {
+        for (uint32_t k = 0; k < ALINK_PREAMBLE_LEN; k++) {
+            uint8_t g = a[k] ^ b[(k + n) % ALINK_PREAMBLE_LEN];   // Gold family
+            g_pre_code[n][k] = g ? -1 : +1;
+        }
+        for (uint32_t k = 0; k < ALINK_DATA_SF; k++)
+            g_data_code[n][k] = g_pre_code[n][k];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CRC32 (IEEE 802.3, same poly as the flash stores)
+// ---------------------------------------------------------------------------
+static uint32_t crc32(const uint8_t *d, uint32_t len) {
+    uint32_t c = 0xFFFFFFFFu;
+    for (uint32_t i = 0; i < len; i++) {
+        c ^= d[i];
+        for (int b = 0; b < 8; b++)
+            c = (c & 1u) ? ((c >> 1) ^ 0xEDB88320u) : (c >> 1);
+    }
+    return ~c;
+}
+
+// ---------------------------------------------------------------------------
+// Hamming(7,4) FEC — single-error-correcting, per nibble
+// ---------------------------------------------------------------------------
+static void hamming_enc(uint8_t nib, uint8_t out[7]) {
+    uint8_t d0 = (nib >> 0) & 1u, d1 = (nib >> 1) & 1u;
+    uint8_t d2 = (nib >> 2) & 1u, d3 = (nib >> 3) & 1u;
+    out[0] = (uint8_t)(d0 ^ d1 ^ d3);   // p1
+    out[1] = (uint8_t)(d0 ^ d2 ^ d3);   // p2
+    out[2] = d0;
+    out[3] = (uint8_t)(d1 ^ d2 ^ d3);   // p3
+    out[4] = d1;
+    out[5] = d2;
+    out[6] = d3;
+}
+
+static uint8_t hamming_dec(const uint8_t in[7]) {
+    uint8_t p1 = in[0], p2 = in[1], d0 = in[2], p3 = in[3];
+    uint8_t d1 = in[4], d2 = in[5], d3 = in[6];
+    uint8_t s1 = (uint8_t)(p1 ^ d0 ^ d1 ^ d3);
+    uint8_t s2 = (uint8_t)(p2 ^ d0 ^ d2 ^ d3);
+    uint8_t s3 = (uint8_t)(p3 ^ d1 ^ d2 ^ d3);
+    uint8_t syn = (uint8_t)(s1 | (s2 << 1) | (s3 << 2));
+    if (syn) {
+        // Syndrome (s1,s2,s3) -> codeword index (see hamming_enc layout):
+        //   001->p1(0) 010->p2(1) 011->d0(2) 100->p3(3)
+        //   101->d1(4) 110->d2(5) 111->d3(6)
+        static const int synmap[8] = { -1, 0, 1, 2, 3, 4, 5, 6 };
+        uint8_t v[7] = { in[0], in[1], in[2], in[3], in[4], in[5], in[6] };
+        int p = synmap[syn & 7u];
+        if (p >= 0) v[p] ^= 1u;
+        d0 = v[2]; d1 = v[4]; d2 = v[5]; d3 = v[6];
+    }
+    return (uint8_t)(d0 | (d1 << 1) | (d2 << 2) | (d3 << 3));
+}
+
+// ---------------------------------------------------------------------------
+// Crypto hook (reserved). Today a no-op pass-through; the frame already
+// carries key_id/nonce/flags so enabling AEAD later needs no wire change.
+// ---------------------------------------------------------------------------
+static bool crypto_seal(uint8_t *payload, uint8_t len, uint8_t key_id, uint32_t nonce) {
+    (void)payload; (void)len; (void)key_id; (void)nonce;
+    return true;   // TODO: AEAD (encrypt-then-MAC), e.g. ChaCha20-Poly1305
+}
+static bool crypto_open(uint8_t *payload, uint8_t len, uint8_t key_id, uint32_t nonce) {
+    (void)payload; (void)len; (void)key_id; (void)nonce;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// TX
+// ---------------------------------------------------------------------------
+static uint8_t  s_tx_chips[ALINK_TX_CHIPS];
+static uint8_t  s_tx_seq;
+static uint32_t s_tx_count;
+static uint8_t  s_pending_seq;        // seq of frame currently being emitted
+static bool     s_pending_note;       // need to record accurate t1 once it starts
+static uint64_t s_last_tx_start_us;
+
+// Build the 434-bit Hamming-coded stream from 31 plaintext bytes, then spread.
+static void build_tx_chips(const uint8_t frame[ALINK_FRAME_BYTES]) {
+    uint8_t bits[ALINK_CODED_BITS];
+    uint32_t bi = 0;
+    for (uint32_t i = 0; i < ALINK_FRAME_BYTES; i++) {
+        uint8_t hi = (uint8_t)(frame[i] >> 4);
+        uint8_t lo = (uint8_t)(frame[i] & 0x0Fu);
+        uint8_t cw[7];
+        hamming_enc(hi, cw);
+        for (int k = 0; k < 7; k++) bits[bi++] = cw[k];
+        hamming_enc(lo, cw);
+        for (int k = 0; k < 7; k++) bits[bi++] = cw[k];
+    }
+
+    uint32_t ci = 0;
+    const int8_t *pre = g_pre_code[g_node_id % ALINK_MAX_NODES];
+    const int8_t *dc  = g_data_code[g_node_id % ALINK_MAX_NODES];
+    for (uint32_t k = 0; k < ALINK_PREAMBLE_LEN; k++)
+        s_tx_chips[ci++] = (pre[k] < 0) ? 1u : 0u;   // amplitude -> phase bit
+    for (uint32_t b = 0; b < ALINK_CODED_BITS; b++) {
+        int amp_bit = (bits[b] ? -1 : +1);
+        for (uint32_t k = 0; k < ALINK_DATA_SF; k++) {
+            int amp = amp_bit * dc[k];              // (1-2b)*code
+            s_tx_chips[ci++] = (amp < 0) ? 1u : 0u;
+        }
+    }
+}
+
+bool acoustic_link_send(uint8_t type, uint8_t flags,
+                        const uint8_t *payload, uint8_t len) {
+    if (len > ALINK_MAX_PAYLOAD) return false;
+    if (buzzer_tx_busy()) return false;
+
+    uint8_t frame[ALINK_FRAME_BYTES];
+    memset(frame, 0, sizeof(frame));
+    uint8_t key_id = 0;
+    uint32_t nonce = 0;
+    frame[0] = ALINK_VERSION;
+    frame[1] = g_node_id;
+    frame[2] = type;
+    frame[3] = s_tx_seq;
+    frame[4] = flags;
+    frame[5] = key_id;
+    frame[6] = (uint8_t)(nonce & 0xFF);
+    frame[7] = (uint8_t)((nonce >> 8) & 0xFF);
+    frame[8] = (uint8_t)((nonce >> 16) & 0xFF);
+    frame[9] = (uint8_t)((nonce >> 24) & 0xFF);
+    frame[10] = len;
+    if (payload && len) memcpy(&frame[11], payload, len);
+
+    // Seal payload region in place (stub today).
+    if (flags & ALINK_FLAG_ENCRYPTED)
+        (void)crypto_seal(&frame[11], ALINK_MAX_PAYLOAD, key_id, nonce);
+
+    uint32_t crc = crc32(frame, 27);
+    frame[27] = (uint8_t)(crc & 0xFF);
+    frame[28] = (uint8_t)((crc >> 8) & 0xFF);
+    frame[29] = (uint8_t)((crc >> 16) & 0xFF);
+    frame[30] = (uint8_t)((crc >> 24) & 0xFF);
+
+    build_tx_chips(frame);
+    if (!buzzer_tx_chips(s_tx_chips, ALINK_TX_CHIPS)) return false;
+
+    s_pending_seq = s_tx_seq;
+    s_pending_note = (type == ALINK_FT_BEACON);
+    s_tx_seq++;
+    s_tx_count++;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Beacon scheduling (slotted-ALOHA-ish: periodic + random jitter)
+// ---------------------------------------------------------------------------
+#define BEACON_BASE_MS   1500u
+#define BEACON_JITTER_MS 500u
+static uint64_t s_next_beacon_us;
+static uint32_t s_lcg = 0x1234567u;
+
+static uint32_t rnd(void) { s_lcg = s_lcg * 1664525u + 1013904223u; return s_lcg; }
+
+static void schedule_tx(void) {
+    uint64_t now = time_us_64();
+    if (s_next_beacon_us == 0) {
+        s_next_beacon_us = now + (uint64_t)BEACON_BASE_MS * 1000u;
+        return;
+    }
+    if (now < s_next_beacon_us) return;
+    if (buzzer_tx_busy()) return;   // listen/hold: don't stomp our own PHY
+
+    uint8_t p[ALINK_MAX_PAYLOAD];
+    memset(p, 0, sizeof(p));
+    uint32_t tx_mono = (uint32_t)now;              // approx send time (low32)
+    uint32_t epoch = het68_time_synced() ? het68_time_epoch_sec() : 0u;
+    p[0] = (uint8_t)(tx_mono & 0xFF);
+    p[1] = (uint8_t)((tx_mono >> 8) & 0xFF);
+    p[2] = (uint8_t)((tx_mono >> 16) & 0xFF);
+    p[3] = (uint8_t)((tx_mono >> 24) & 0xFF);
+    p[4] = (uint8_t)(epoch & 0xFF);
+    p[5] = (uint8_t)((epoch >> 8) & 0xFF);
+    p[6] = (uint8_t)((epoch >> 16) & 0xFF);
+    p[7] = (uint8_t)((epoch >> 24) & 0xFF);
+
+    uint8_t echo_node = 0xFF, echo_seq = 0;
+    uint32_t t_reply = 0;
+    (void)node_store_pending_echo(&echo_node, &echo_seq, &t_reply, now);
+    p[8] = echo_node;
+    p[9]  = (uint8_t)(t_reply & 0xFF);
+    p[10] = (uint8_t)((t_reply >> 8) & 0xFF);
+    p[11] = (uint8_t)((t_reply >> 16) & 0xFF);
+    p[12] = (uint8_t)((t_reply >> 24) & 0xFF);
+    p[13] = echo_seq;
+    p[14] = het68_time_synced() ? 1u : 0u;
+
+    uint8_t flags = het68_time_synced() ? ALINK_FLAG_SYNCED : 0u;
+    (void)acoustic_link_send(ALINK_FT_BEACON, flags, p, ALINK_MAX_PAYLOAD);
+
+    uint32_t jitter = rnd() % (BEACON_JITTER_MS * 1000u);
+    s_next_beacon_us = now + (uint64_t)BEACON_BASE_MS * 1000u + jitter;
+}
+
+// ---------------------------------------------------------------------------
+// RX ring (SPSC: producer = USB frame builder, consumer = poll)
+// ---------------------------------------------------------------------------
+#define RX_RING 8192u
+static int16_t          s_rx_ring[RX_RING];
+static volatile uint32_t s_rx_head;   // producer
+static volatile uint32_t s_rx_tail;   // consumer
+
+void acoustic_link_rx_push(int16_t mono) {
+    uint32_t h = s_rx_head;
+    uint32_t nh = (h + 1u) & (RX_RING - 1u);
+    if (nh == s_rx_tail) return;       // full: drop (bounded, non-blocking)
+    s_rx_ring[h] = mono;
+    s_rx_head = nh;
+}
+
+// ---------------------------------------------------------------------------
+// RX matched filter / despreader
+// ---------------------------------------------------------------------------
+static float s_cos_lut[ALINK_SAMPLES_CYCLE];
+static float s_sin_lut[ALINK_SAMPLES_CYCLE];
+static uint32_t s_smp_phase;
+
+// Integrate-and-dump chip accumulator.
+static float s_i_acc, s_q_acc;
+static uint32_t s_chip_smp;
+
+// Preamble chip history (circular).
+static float s_hist_i[ALINK_PREAMBLE_LEN];
+static float s_hist_q[ALINK_PREAMBLE_LEN];
+static uint32_t s_hist_head;
+static uint32_t s_hist_fill;
+
+// Receiver state machine.
+enum { RX_SEARCH = 0, RX_DATA };
+static uint8_t  s_rx_state;
+static uint8_t  s_rx_node;       // detected sender code index
+static float    s_rx_cos, s_rx_sin;  // channel phase reference
+static uint64_t s_rx_toa_us;
+static float    s_rx_q;
+static uint32_t s_bit_idx;
+static uint32_t s_chip_in_bit;
+static float    s_bit_i, s_bit_q;
+static uint8_t  s_coded[ALINK_CODED_BITS];
+
+static uint32_t s_rx_count;
+static uint32_t s_rx_bad_crc;
+static volatile bool s_wifi_wake_pending;
+
+#define DETECT_RHO   0.30f     // normalized correlation threshold
+#define DETECT_EMIN  1.0e6f    // minimum window energy to consider a peak
+
+static void rx_reset_search(void) {
+    s_rx_state = RX_SEARCH;
+    s_bit_idx = 0;
+    s_chip_in_bit = 0;
+    s_bit_i = s_bit_q = 0.0f;
+}
+
+static void dispatch_frame(const alink_frame_t *f);
+
+static void finalize_frame(void) {
+    uint8_t bytes[ALINK_FRAME_BYTES];
+    for (uint32_t i = 0; i < ALINK_FRAME_BYTES; i++) {
+        uint8_t hi = hamming_dec(&s_coded[(i * 2u) * 7u]);
+        uint8_t lo = hamming_dec(&s_coded[(i * 2u + 1u) * 7u]);
+        bytes[i] = (uint8_t)((hi << 4) | (lo & 0x0Fu));
+    }
+    uint32_t crc = crc32(bytes, 27);
+    uint32_t rx_crc = (uint32_t)bytes[27] | ((uint32_t)bytes[28] << 8) |
+                      ((uint32_t)bytes[29] << 16) | ((uint32_t)bytes[30] << 24);
+    if (crc != rx_crc || bytes[0] != ALINK_VERSION) {
+        s_rx_bad_crc++;
+        rx_reset_search();
+        return;
+    }
+    alink_frame_t f;
+    f.version = bytes[0];
+    f.node_id = bytes[1];
+    f.type = bytes[2];
+    f.seq = bytes[3];
+    f.flags = bytes[4];
+    f.key_id = bytes[5];
+    f.nonce = (uint32_t)bytes[6] | ((uint32_t)bytes[7] << 8) |
+              ((uint32_t)bytes[8] << 16) | ((uint32_t)bytes[9] << 24);
+    f.len = bytes[10] > ALINK_MAX_PAYLOAD ? ALINK_MAX_PAYLOAD : bytes[10];
+    memcpy(f.payload, &bytes[11], ALINK_MAX_PAYLOAD);
+    f.rx_time_us = s_rx_toa_us;
+    f.corr_q = s_rx_q;
+    if (f.flags & ALINK_FLAG_ENCRYPTED)
+        (void)crypto_open(f.payload, ALINK_MAX_PAYLOAD, f.key_id, f.nonce);
+    s_rx_count++;
+    dispatch_frame(&f);
+    rx_reset_search();
+}
+
+// One completed chip (complex) at local time chip_us.
+static void rx_on_chip(float ci, float cq, uint64_t chip_us) {
+    if (s_rx_state == RX_DATA) {
+        const int8_t *dc = g_data_code[s_rx_node];
+        s_bit_i += ci * (float)dc[s_chip_in_bit];
+        s_bit_q += cq * (float)dc[s_chip_in_bit];
+        if (++s_chip_in_bit >= ALINK_DATA_SF) {
+            float val = s_bit_i * s_rx_cos + s_bit_q * s_rx_sin;  // derotate
+            s_coded[s_bit_idx] = (val < 0.0f) ? 1u : 0u;
+            s_bit_idx++;
+            s_chip_in_bit = 0;
+            s_bit_i = s_bit_q = 0.0f;
+            if (s_bit_idx >= ALINK_CODED_BITS) finalize_frame();
+        }
+        return;
+    }
+
+    // SEARCH: push chip into history, correlate against candidate codes.
+    s_hist_i[s_hist_head] = ci;
+    s_hist_q[s_hist_head] = cq;
+    s_hist_head = (s_hist_head + 1u) % ALINK_PREAMBLE_LEN;
+    if (s_hist_fill < ALINK_PREAMBLE_LEN) { s_hist_fill++; return; }
+
+    float energy = 0.0f;
+    for (uint32_t k = 0; k < ALINK_PREAMBLE_LEN; k++)
+        energy += s_hist_i[k] * s_hist_i[k] + s_hist_q[k] * s_hist_q[k];
+    if (energy < DETECT_EMIN) return;
+
+    int best_node = -1;
+    float best_mag2 = 0.0f, best_ci = 0.0f, best_cq = 0.0f;
+    for (uint32_t n = 0; n < ALINK_MAX_NODES; n++) {
+        const int8_t *code = g_pre_code[n];
+        float ri = 0.0f, rq = 0.0f;
+        // oldest chip is at s_hist_head (just overwritten pos is newest-1);
+        // align code[0] with oldest sample.
+        uint32_t idx = s_hist_head;
+        for (uint32_t k = 0; k < ALINK_PREAMBLE_LEN; k++) {
+            float c = (float)code[k];
+            ri += c * s_hist_i[idx];
+            rq += c * s_hist_q[idx];
+            idx = (idx + 1u) % ALINK_PREAMBLE_LEN;
+        }
+        float mag2 = ri * ri + rq * rq;
+        if (mag2 > best_mag2) { best_mag2 = mag2; best_node = (int)n; best_ci = ri; best_cq = rq; }
+    }
+
+    float rho = best_mag2 / ((float)ALINK_PREAMBLE_LEN * energy);
+    if (best_node >= 0 && rho > DETECT_RHO) {
+        float mag = sqrtf(best_mag2);
+        if (mag < 1.0f) return;
+        s_rx_node = (uint8_t)best_node;
+        s_rx_cos = best_ci / mag;
+        s_rx_sin = best_cq / mag;
+        s_rx_toa_us = chip_us;
+        s_rx_q = rho;
+        s_rx_state = RX_DATA;
+        s_bit_idx = 0;
+        s_chip_in_bit = 0;
+        s_bit_i = s_bit_q = 0.0f;
+        // Clear history so the next search starts fresh after this frame.
+        s_hist_fill = 0;
+    }
+}
+
+void acoustic_link_poll(void) {
+    schedule_tx();
+
+    // Record the accurate preamble start time for our outstanding beacon poll.
+    if (s_pending_note) {
+        uint64_t st = buzzer_tx_start_us();
+        if (st != 0 && st != s_last_tx_start_us) {
+            node_store_note_tx(s_pending_seq, st);
+            s_last_tx_start_us = st;
+            s_pending_note = false;
+        }
+    }
+
+    uint32_t head = s_rx_head;
+    uint32_t tail = s_rx_tail;
+    uint32_t avail = (head - tail) & (RX_RING - 1u);
+    if (avail == 0u) return;
+
+    uint64_t now = time_us_64();
+    uint32_t remaining = avail;
+    while (tail != head) {
+        int16_t x = s_rx_ring[tail];
+        tail = (tail + 1u) & (RX_RING - 1u);
+        remaining--;
+
+        float xf = (float)x;
+        uint32_t p = s_smp_phase;
+        s_i_acc += xf * s_cos_lut[p];
+        s_q_acc += xf * s_sin_lut[p];
+        s_smp_phase = (p + 1u >= ALINK_SAMPLES_CYCLE) ? 0u : (p + 1u);
+
+        if (++s_chip_smp >= ALINK_SAMPLES_CHIP) {
+            uint64_t chip_us = now - (uint64_t)remaining * 1000000ull / ALINK_FS_HZ;
+            rx_on_chip(s_i_acc, s_q_acc, chip_us);
+            s_i_acc = s_q_acc = 0.0f;
+            s_chip_smp = 0;
+        }
+    }
+    s_rx_tail = tail;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+#if HET68_WIFI_WAKE
+static void wifi_wake(uint8_t token) {
+    s_wifi_wake_pending = true;
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("LINK: WIFI_WAKE token=");
+    dbg_putu32(token);
+    dbg_puts(" — Wi-Fi STA bring-up requested (bulk sync / OTA)\n");
+    dbg_line_unlock(lock);
+    // Actual STA connect is deferred: it needs SSID/credential provisioning and
+    // must coexist with the BTstack/RID cyw43_arch instance. The application
+    // layer polls acoustic_link_wifi_wake_pending() to drive the connect + OTA.
+}
+#else
+static void wifi_wake(uint8_t token) {
+    (void)token;
+    s_wifi_wake_pending = true;   // recorded even on non-wireless boards
+    dbg_puts("LINK: WIFI_WAKE received — no Wi-Fi on this board\n");
+}
+#endif
+
+static void dispatch_frame(const alink_frame_t *f) {
+    switch (f->type) {
+        case ALINK_FT_BEACON: {
+            uint32_t peer_tx = (uint32_t)f->payload[0] | ((uint32_t)f->payload[1] << 8) |
+                               ((uint32_t)f->payload[2] << 16) | ((uint32_t)f->payload[3] << 24);
+            uint32_t epoch   = (uint32_t)f->payload[4] | ((uint32_t)f->payload[5] << 8) |
+                               ((uint32_t)f->payload[6] << 16) | ((uint32_t)f->payload[7] << 24);
+            uint8_t echo_node = f->payload[8];
+            uint32_t t_reply = (uint32_t)f->payload[9] | ((uint32_t)f->payload[10] << 8) |
+                               ((uint32_t)f->payload[11] << 16) | ((uint32_t)f->payload[12] << 24);
+            uint8_t echo_seq = f->payload[13];
+            bool peer_synced = (f->flags & ALINK_FLAG_SYNCED) != 0;
+
+            node_store_on_beacon(g_node_id, f->node_id, f->seq, f->rx_time_us,
+                                 peer_tx, echo_node, echo_seq, t_reply,
+                                 peer_synced, f->corr_q, doa_c_sound_m_s());
+
+            // Coarse time adoption from a synced peer when we are unsynced.
+            if (peer_synced && epoch > 1700000000u && !het68_time_synced())
+                (void)het68_time_sync_from(epoch, HET68_TIME_SRC_ACOUSTIC, 60u);
+            break;
+        }
+        case ALINK_FT_CTRL: {
+            uint8_t sub = f->payload[0];
+            if (sub == ALINK_CTRL_WIFI_WAKE) wifi_wake(f->payload[1]);
+            else if (sub == ALINK_CTRL_OTA_REQ) dbg_puts("LINK: OTA_REQ received\n");
+            break;
+        }
+        case ALINK_FT_DETECT: {
+            uint32_t lock = dbg_line_lock();
+            dbg_puts("LINK DETECT from=");
+            dbg_putu32(f->node_id);
+            dbg_puts(" cls=");
+            dbg_putu32(f->payload[0]);
+            dbg_putc('\n');
+            dbg_line_unlock(lock);
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+void acoustic_link_init(uint8_t node_id) {
+    g_node_id = node_id;
+    build_codes();
+    for (uint32_t i = 0; i < ALINK_SAMPLES_CYCLE; i++) {
+        float a = 2.0f * 3.14159265f * (float)i / (float)ALINK_SAMPLES_CYCLE;
+        s_cos_lut[i] = cosf(a);
+        s_sin_lut[i] = sinf(a);
+    }
+    s_smp_phase = 0;
+    s_i_acc = s_q_acc = 0.0f;
+    s_chip_smp = 0;
+    s_hist_head = 0;
+    s_hist_fill = 0;
+    rx_reset_search();
+    s_rx_head = s_rx_tail = 0;
+    s_next_beacon_us = 0;
+    node_store_init();
+}
+
+void acoustic_link_set_node_id(uint8_t id) { g_node_id = id; }
+uint8_t acoustic_link_node_id(void) { return g_node_id; }
+
+bool acoustic_link_send_wifi_wake(uint8_t channel_token) {
+    uint8_t p[ALINK_MAX_PAYLOAD];
+    memset(p, 0, sizeof(p));
+    p[0] = ALINK_CTRL_WIFI_WAKE;
+    p[1] = channel_token;
+    return acoustic_link_send(ALINK_FT_CTRL, 0u, p, ALINK_MAX_PAYLOAD);
+}
+
+uint32_t acoustic_link_tx_count(void) { return s_tx_count; }
+uint32_t acoustic_link_rx_count(void) { return s_rx_count; }
+uint32_t acoustic_link_rx_bad_crc(void) { return s_rx_bad_crc; }
+bool acoustic_link_tx_busy(void) { return buzzer_tx_busy(); }
+bool acoustic_link_wifi_wake_pending(void) { return s_wifi_wake_pending; }
+
+void acoustic_link_status_uart(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("LINK node=");
+    dbg_putu32(g_node_id);
+    dbg_puts(" tx=");
+    dbg_putu32(s_tx_count);
+    dbg_puts(" rx=");
+    dbg_putu32(s_rx_count);
+    dbg_puts(" bad_crc=");
+    dbg_putu32(s_rx_bad_crc);
+    dbg_puts(" peers=");
+    dbg_putu32(node_store_count());
+    dbg_puts(" wifi_wake=");
+    dbg_puts(s_wifi_wake_pending ? "1" : "0");
+    dbg_putc('\n');
+    dbg_line_unlock(lock);
+    node_store_list_uart();
+}

--- a/acoustic_link.h
+++ b/acoustic_link.h
@@ -1,0 +1,97 @@
+// acoustic_link.h — node-to-node acoustic link over the GP6/GP7 4 kHz piezo.
+//
+// PHY : DSSS-BPSK on the existing PS1240 H-bridge beacon engine (buzzer.c).
+// MAC : per-node CDMA code (Gold family) + slotted-ALOHA jitter, fixed frame.
+// SEC : Hamming(7,4) FEC + CRC32, reserved key_id/nonce/flags for future AEAD.
+// APP : BEACON (ranging + coarse time), DETECT (summary), CTRL (wifi-wake/OTA).
+//
+// RX rides on the 6-mic 48 kHz capture: main.c feeds a mono mix to
+// acoustic_link_rx_push(); acoustic_link_poll() runs a bounded matched filter.
+// No malloc, no blocking in the realtime path (see AGENTS.md).
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+// --- PHY timing (locked to the buzzer carrier) ------------------------------
+#define ALINK_CARRIER_HZ     4000u
+#define ALINK_FS_HZ          48000u
+#define ALINK_SAMPLES_CYCLE  (ALINK_FS_HZ / ALINK_CARRIER_HZ)          // 12
+#define ALINK_CYCLES_CHIP    8u
+#define ALINK_SAMPLES_CHIP   (ALINK_SAMPLES_CYCLE * ALINK_CYCLES_CHIP) // 96
+#define ALINK_CHIP_HZ        (ALINK_FS_HZ / ALINK_SAMPLES_CHIP)        // 500
+
+// --- Spreading / framing ----------------------------------------------------
+#define ALINK_PREAMBLE_LEN   127u   // length-127 m-sequence / Gold code
+#define ALINK_DATA_SF        8u     // chips per coded data bit
+#define ALINK_MAX_NODES      8u     // distinct CDMA codes tracked on RX
+
+#define ALINK_VERSION        1u
+#define ALINK_MAX_PAYLOAD    16u
+// Fixed on-air plaintext frame (padded): keeps RX sizing constant.
+//   [0]=ver [1]=node_id [2]=type [3]=seq [4]=flags [5]=key_id
+//   [6..9]=nonce [10]=len [11..26]=payload[16] [27..30]=crc32
+#define ALINK_FRAME_BYTES    31u
+// Hamming(7,4): 2 nibbles/byte * 7 bits.
+#define ALINK_CODED_BITS     (ALINK_FRAME_BYTES * 2u * 7u)             // 434
+#define ALINK_TX_CHIPS       (ALINK_PREAMBLE_LEN + ALINK_CODED_BITS * ALINK_DATA_SF) // 3599
+
+// Frame types.
+enum {
+    ALINK_FT_BEACON = 0,   // ranging + coarse time sync
+    ALINK_FT_DETECT = 1,   // compact detection summary
+    ALINK_FT_CTRL   = 2,   // control-plane (wifi wake, OTA request)
+    ALINK_FT_ACK    = 3,
+};
+
+// CTRL subtypes (payload[0]).
+enum {
+    ALINK_CTRL_WIFI_WAKE = 1,
+    ALINK_CTRL_OTA_REQ   = 2,
+};
+
+// Header flags.
+#define ALINK_FLAG_ENCRYPTED  0x01u   // payload sealed (reserved; stub today)
+#define ALINK_FLAG_ACK_REQ    0x02u
+#define ALINK_FLAG_SYNCED     0x04u   // sender clock is synced (epoch valid)
+
+// Decoded frame handed to the dispatcher / CLI.
+typedef struct {
+    uint8_t  version;
+    uint8_t  node_id;
+    uint8_t  type;
+    uint8_t  seq;
+    uint8_t  flags;
+    uint8_t  key_id;
+    uint32_t nonce;
+    uint8_t  len;
+    uint8_t  payload[ALINK_MAX_PAYLOAD];
+    uint64_t rx_time_us;   // local monotonic ToA (matched-filter peak)
+    float    corr_q;       // normalized correlation quality 0..1
+} alink_frame_t;
+
+void acoustic_link_init(uint8_t node_id);
+void acoustic_link_set_node_id(uint8_t id);
+uint8_t acoustic_link_node_id(void);
+
+// Queue one frame for transmission (non-blocking). Payload padded to 16 B.
+// Returns false if the PHY is busy or args invalid.
+bool acoustic_link_send(uint8_t type, uint8_t flags,
+                        const uint8_t *payload, uint8_t len);
+
+// Convenience: broadcast a CTRL WIFI_WAKE with a rendezvous token.
+bool acoustic_link_send_wifi_wake(uint8_t channel_token);
+
+// RX sample sink — cheap, called from the USB/I2S frame builder (core0).
+void acoustic_link_rx_push(int16_t mono);
+
+// Main-loop service: drains the RX ring (bounded), runs the matched filter,
+// dispatches frames, and schedules periodic beacons. Call each loop iteration.
+void acoustic_link_poll(void);
+
+// Diagnostics.
+uint32_t acoustic_link_tx_count(void);
+uint32_t acoustic_link_rx_count(void);
+uint32_t acoustic_link_rx_bad_crc(void);
+bool     acoustic_link_tx_busy(void);
+bool     acoustic_link_wifi_wake_pending(void);
+void     acoustic_link_status_uart(void);

--- a/buzzer.c
+++ b/buzzer.c
@@ -17,6 +17,7 @@
 #include "pico/stdlib.h"
 #include "hardware/pwm.h"
 #include "hardware/clocks.h"
+#include <stddef.h>
 
 #define BUZZER_PIN_A        6u
 #define BUZZER_PIN_B        7u
@@ -39,6 +40,14 @@ static repeating_timer_t s_timer;
 static volatile int32_t  s_chip = -1;          // -1 = idle, else 0..PN_LEN-1
 static volatile uint32_t s_idle = 0;
 static volatile uint32_t s_beacons = 0;
+
+// --- Chip-stream TX state (acoustic link) -----------------------------------
+static const uint8_t   *volatile s_stream;      // chip buffer (referenced)
+static volatile uint32_t s_stream_len;
+static volatile uint32_t s_stream_idx;
+static volatile bool     s_stream_active;
+static volatile bool     s_stream_pending;      // commit flag; ISR starts next tick
+static volatile uint64_t s_stream_start_us;
 
 // Differential drive for one PN chip: chip=1 -> phase 0, chip=0 -> phase 180.
 static inline void buzzer_set_drive(uint8_t chip) {
@@ -64,6 +73,29 @@ static void buzzer_build_pn(void) {
 
 static bool buzzer_tick(repeating_timer_t *t) {
     (void)t;
+
+    // Acoustic-link chip stream pre-empts the periodic PN beacon.
+    if (s_stream_pending && !s_stream_active) {
+        s_stream_active = true;
+        s_stream_pending = false;
+        s_stream_idx = 0;
+    }
+    if (s_stream_active) {
+        uint32_t idx = s_stream_idx;
+        if (idx == 0u) s_stream_start_us = time_us_64();
+        buzzer_set_drive(s_stream[idx]);
+        idx++;
+        s_stream_idx = idx;
+        if (idx >= s_stream_len) {
+            s_stream_active = false;
+            buzzer_set_silent();
+            // Do not immediately fire the beacon on top of the stream tail.
+            s_chip = -1;
+            s_idle = 0;
+        }
+        return true;
+    }
+
     if (s_chip >= 0) {
         buzzer_set_drive(s_pn[s_chip]);
         s_chip++;
@@ -103,4 +135,23 @@ void buzzer_init(void) {
 
 uint32_t buzzer_beacon_count(void) {
     return s_beacons;
+}
+
+bool buzzer_tx_chips(const uint8_t *chips, uint32_t n_chips) {
+    if (chips == NULL || n_chips == 0u) return false;
+    if (s_stream_active || s_stream_pending) return false;
+    s_stream = chips;
+    s_stream_len = n_chips;
+    s_stream_idx = 0;
+    // Commit last: the ISR only starts once s_stream_pending is observed true.
+    s_stream_pending = true;
+    return true;
+}
+
+bool buzzer_tx_busy(void) {
+    return s_stream_active || s_stream_pending;
+}
+
+uint64_t buzzer_tx_start_us(void) {
+    return s_stream_start_us;
 }

--- a/buzzer.h
+++ b/buzzer.h
@@ -12,6 +12,7 @@
 // sync. The RX/ranging side is a later phase; this module only emits.
 #pragma once
 #include <stdint.h>
+#include <stdbool.h>
 
 // Configure the PWM carrier + the chip-rate timer. Silent until the first
 // scheduled beacon. Call once from core0 after stdio/clocks are up.
@@ -19,3 +20,19 @@ void buzzer_init(void);
 
 // Number of beacon bursts emitted so far (for heartbeat/diagnostics).
 uint32_t buzzer_beacon_count(void);
+
+// --- Chip-stream TX (acoustic link PHY) --------------------------------------
+// Hand the chip-rate ISR an arbitrary BPSK chip sequence (each byte 0/1 selects
+// the carrier phase). The chips play out one per chip tick, pre-empting the
+// periodic PN beacon; the free-running beacon resumes when the stream ends.
+//
+// The buffer is referenced (not copied) and MUST stay valid until
+// buzzer_tx_busy() returns false. Returns false if a stream is already active.
+bool buzzer_tx_chips(const uint8_t *chips, uint32_t n_chips);
+
+// True while a queued chip stream is pending or transmitting.
+bool buzzer_tx_busy(void);
+
+// Absolute time (microseconds since boot) at which chip 0 of the current or
+// most recent stream was emitted. 0 until the first stream starts.
+uint64_t buzzer_tx_start_us(void);

--- a/cli.c
+++ b/cli.c
@@ -8,6 +8,8 @@
 #include "doa.h"
 #include "het68_time.h"
 #include "remote_id.h"
+#include "acoustic_link.h"
+#include "node_store.h"
 #include <string.h>
 
 static char g_buf[192];
@@ -44,6 +46,10 @@ void cli_print_help(void) {
     dbg_puts("DRONE CLEAR          — erase known-drone flash registry\n");
     dbg_puts("BARO                 — Grove DPS310 pressure/temperature (GP2/GP3)\n");
     dbg_puts("BARO RH <0-100>      — assumed RH percent for sound speed (default 50)\n");
+    dbg_puts("LINK                 — acoustic node link status + peer/ranging table\n");
+    dbg_puts("LINK ID <0-7>        — set this node's acoustic id / CDMA code\n");
+    dbg_puts("LINK BEACON          — send one beacon now (ranging/sync)\n");
+    dbg_puts("LINK WIFI            — broadcast WIFI_WAKE (bulk sync / OTA)\n");
     dbg_puts("RID LIST             — OpenDroneID BLE tracks (CYW43 boards)\n");
     dbg_puts("RID ON | RID OFF     — enable/disable BLE Remote ID scan\n");
     dbg_puts("Note: DET timestamps after TIME SYNC (UART or RID System msg).\n");
@@ -129,6 +135,7 @@ void cli_print_status(void) {
     dbg_line_unlock(lock);
 
     dps310_dump_uart();
+    acoustic_link_status_uart();
     entity_store_dump_uart();
     detection_log_list_uart();
     drone_store_list_uart();
@@ -331,6 +338,38 @@ static void handle_line(char *line) {
         return;
     }
 
+    if (strcmp(line, "LINK") == 0 || strcmp(line, "LINK LIST") == 0) {
+        acoustic_link_status_uart();
+        return;
+    }
+    if (strncmp(line, "LINK ID ", 8) == 0) {
+        uint32_t id = parse_u32(line + 8);
+        if (id >= 8u) {
+            dbg_puts("LINK ID ERR: need 0..7\n");
+        } else {
+            acoustic_link_set_node_id((uint8_t)id);
+            dbg_puts("LINK ID=");
+            dbg_putu32(id);
+            dbg_putc('\n');
+        }
+        return;
+    }
+    if (strcmp(line, "LINK BEACON") == 0) {
+        uint8_t flags = het68_time_synced() ? ALINK_FLAG_SYNCED : 0u;
+        if (acoustic_link_send(ALINK_FT_BEACON, flags, NULL, 0))
+            dbg_puts("LINK: beacon queued\n");
+        else
+            dbg_puts("LINK: TX busy\n");
+        return;
+    }
+    if (strcmp(line, "LINK WIFI") == 0 || strcmp(line, "LINK WIFI WAKE") == 0) {
+        if (acoustic_link_send_wifi_wake(1u))
+            dbg_puts("LINK: WIFI_WAKE queued\n");
+        else
+            dbg_puts("LINK: TX busy\n");
+        return;
+    }
+
     if (strcmp(line, "RID LIST") == 0 || strcmp(line, "RID") == 0) {
         remote_id_list_uart();
         return;
@@ -358,6 +397,7 @@ static void handle_line(char *line) {
         strncmp(line, "TIME", 4) == 0 || strncmp(line, "LOG", 3) == 0 ||
         strncmp(line, "RID", 3) == 0 || strncmp(line, "DRONE", 5) == 0 ||
         strncmp(line, "BARO", 4) == 0 || strncmp(line, "DPS", 3) == 0 ||
+        strncmp(line, "LINK", 4) == 0 ||
         strncmp(line, "STATUS", 6) == 0) {
         dbg_puts("?: unknown command — HELP\n");
     }

--- a/het68_time.c
+++ b/het68_time.c
@@ -62,9 +62,10 @@ het68_time_src_t het68_time_source(void) {
 
 const char *het68_time_source_name(het68_time_src_t src) {
     switch (src) {
-        case HET68_TIME_SRC_UART: return "uart";
-        case HET68_TIME_SRC_RID:  return "rid";
-        default:                  return "none";
+        case HET68_TIME_SRC_UART:     return "uart";
+        case HET68_TIME_SRC_RID:      return "rid";
+        case HET68_TIME_SRC_ACOUSTIC: return "acoustic";
+        default:                      return "none";
     }
 }
 

--- a/het68_time.h
+++ b/het68_time.h
@@ -4,9 +4,10 @@
 #include <stdbool.h>
 
 typedef enum {
-    HET68_TIME_SRC_NONE = 0,
-    HET68_TIME_SRC_UART = 1,
-    HET68_TIME_SRC_RID  = 2,
+    HET68_TIME_SRC_NONE     = 0,
+    HET68_TIME_SRC_UART     = 1,
+    HET68_TIME_SRC_RID      = 2,
+    HET68_TIME_SRC_ACOUSTIC = 3,   // adopted from a synced peer over the piezo link
 } het68_time_src_t;
 
 void het68_time_init(void);

--- a/main.c
+++ b/main.c
@@ -32,6 +32,7 @@
 #include "het68_time.h"
 #include "drone_store.h"
 #include "dps310.h"
+#include "acoustic_link.h"
 #include "cli.h"
 
 // Apply baro-derived speed of sound to DOA when a fresh sample exists.
@@ -369,6 +370,12 @@ static void build_usb_frame_from_i2s(uint8_t read_half) {
             *out++ = (uint8_t)((s24 >> 16) & 0xFF);
         }
         doa_ring_push(ring6);
+
+        // Feed a mono mix to the acoustic node link RX (cheap; matched filter
+        // runs later in acoustic_link_poll()).
+        int32_t mono = 0;
+        for (int i = 0; i < 6; i++) mono += ring6[i];
+        acoustic_link_rx_push((int16_t)(mono / 6));
     }
     for (int i = 0; i < 6; i++) {
         dbg_i2s_peak[i] = peak[i];
@@ -881,6 +888,18 @@ int main(void)
     else
         dbg_puts("RID: skipped (board has no Wi-Fi/BT)\n");
 
+    // Acoustic node link on the GP6/GP7 piezo (DSSS-BPSK) + mic-array RX.
+    {
+        uint8_t node_id = 0;
+#ifdef HET68_NODE_ID
+        node_id = (uint8_t)(HET68_NODE_ID);
+#endif
+        acoustic_link_init(node_id);
+        dbg_puts("LINK: acoustic node link (GP6/GP7 4kHz DSSS) node=");
+        dbg_putu32(node_id);
+        dbg_putc('\n');
+    }
+
     // Optional Grove DPS310 on free I2C1 pins GP2 (SDA) / GP3 (SCL).
     if (dps310_init()) {
         // A few polls so STATUS/boot can show c=… before the main loop.
@@ -940,6 +959,7 @@ int main(void)
         remote_id_poll();
         dps310_poll();
         baro_update_sound_speed();
+        acoustic_link_poll();
 #endif
         // Audio frames are produced in tud_audio_tx_done_pre_load_cb(), driven by
         // the USB IN cadence — nothing to pump from the main loop here.

--- a/node_store.c
+++ b/node_store.c
@@ -1,0 +1,186 @@
+// node_store.c — peer table + acoustic single-sided two-way ranging (SS-TWR).
+//
+// SS-TWR with broadcast beacons:
+//   A sends poll seqA at t1(A).  B hears it at t2(B).
+//   B sends beacon at t3(B) echoing {A, seqA, t_reply=t3-t2}.
+//   A hears B at t4(A); Tround = t4 - t1; ToF = (Tround - t_reply)/2.
+//   distance = ToF * c(baro).   offset(A-B) = t4 - t3 - ToF.
+// RAM-only, bounded, no blocking.
+#include "node_store.h"
+#include "debug_io.h"
+#include <string.h>
+
+// Ring of our recent outgoing poll timestamps, looked up by seq on echo.
+#define POLL_HIST 8u
+static uint8_t  g_poll_seq[POLL_HIST];
+static uint64_t g_poll_us[POLL_HIST];
+static uint32_t g_poll_head;
+static bool     g_poll_valid[POLL_HIST];
+
+static node_slot_t g_slots[NODE_STORE_MAX];
+static uint32_t    g_count;
+static int         g_last_heard = -1;   // slot index of most recent beacon
+
+// Sanity window for a valid time-of-flight (0..~0.6 s ~= 200 m).
+#define TOF_MAX_US 600000
+
+static void put_f2(float v) {
+    if (v < 0.0f) { dbg_putc('-'); v = -v; }
+    uint32_t ip = (uint32_t)v;
+    uint32_t fp = (uint32_t)((v - (float)ip) * 100.0f + 0.5f);
+    if (fp >= 100u) { ip++; fp = 0u; }
+    dbg_putu32(ip);
+    dbg_putc('.');
+    if (fp < 10u) dbg_putc('0');
+    dbg_putu32(fp);
+}
+
+static void put_i64(int64_t v) {
+    if (v < 0) { dbg_putc('-'); v = -v; }
+    dbg_putu32((uint32_t)v);
+}
+
+void node_store_init(void) {
+    memset(g_slots, 0, sizeof(g_slots));
+    memset(g_poll_valid, 0, sizeof(g_poll_valid));
+    g_count = 0;
+    g_poll_head = 0;
+    g_last_heard = -1;
+}
+
+void node_store_note_tx(uint8_t seq, uint64_t tx_time_us) {
+    g_poll_seq[g_poll_head] = seq;
+    g_poll_us[g_poll_head] = tx_time_us;
+    g_poll_valid[g_poll_head] = true;
+    g_poll_head = (g_poll_head + 1u) % POLL_HIST;
+}
+
+static bool lookup_poll(uint8_t seq, uint64_t *t1_out) {
+    for (uint32_t i = 0; i < POLL_HIST; i++) {
+        if (g_poll_valid[i] && g_poll_seq[i] == seq) {
+            *t1_out = g_poll_us[i];
+            return true;
+        }
+    }
+    return false;
+}
+
+static int find_or_alloc(uint8_t node_id) {
+    int free_i = -1, oldest_i = 0;
+    uint64_t oldest = UINT64_MAX;
+    for (uint32_t i = 0; i < NODE_STORE_MAX; i++) {
+        if (g_slots[i].used) {
+            if (g_slots[i].node_id == node_id) return (int)i;
+            if (g_slots[i].last_rx_us < oldest) {
+                oldest = g_slots[i].last_rx_us;
+                oldest_i = (int)i;
+            }
+        } else if (free_i < 0) {
+            free_i = (int)i;
+        }
+    }
+    int idx = (free_i >= 0) ? free_i : oldest_i;
+    memset(&g_slots[idx], 0, sizeof(g_slots[idx]));
+    g_slots[idx].used = 1;
+    g_slots[idx].node_id = node_id;
+    return idx;
+}
+
+void node_store_on_beacon(uint8_t self_id, uint8_t peer_id, uint8_t peer_seq,
+                          uint64_t rx_time_us,
+                          uint32_t peer_tx_mono_us,
+                          uint8_t echo_node, uint8_t echo_seq,
+                          uint32_t t_reply_us,
+                          bool peer_synced,
+                          float corr_q, float c_sound_m_s) {
+    int idx = find_or_alloc(peer_id);
+    node_slot_t *s = &g_slots[idx];
+    s->corr_q = corr_q;
+    s->synced = peer_synced ? 1u : 0u;
+    s->last_rx_us = rx_time_us;
+    s->last_peer_seq = peer_seq;
+    s->rx_count++;
+    g_last_heard = idx;
+
+    // Recount live peers.
+    uint32_t n = 0;
+    for (uint32_t i = 0; i < NODE_STORE_MAX; i++) if (g_slots[i].used) n++;
+    g_count = n;
+
+    // Ranging: this beacon echoes one of our polls.
+    if (echo_node == self_id) {
+        uint64_t t1 = 0;
+        if (lookup_poll(echo_seq, &t1) && rx_time_us > t1) {
+            uint64_t tround = rx_time_us - t1;
+            if ((uint64_t)t_reply_us < tround) {
+                int64_t tof = ((int64_t)tround - (int64_t)t_reply_us) / 2;
+                if (tof >= 0 && tof < TOF_MAX_US) {
+                    float dist = (float)tof * 1e-6f * c_sound_m_s;
+                    s->distance_m = dist;
+                    s->rng_valid = 1u;
+                    // Coarse clock offset: t4 - t3 - ToF, with t3 = peer_tx_mono.
+                    s->clock_offset_us =
+                        (int64_t)rx_time_us - (int64_t)peer_tx_mono_us - tof;
+                }
+            }
+        }
+    }
+}
+
+int node_store_pending_echo(uint8_t *echo_node, uint8_t *echo_seq,
+                            uint32_t *t_reply_us, uint64_t now_us) {
+    if (g_last_heard < 0) return -1;
+    node_slot_t *s = &g_slots[g_last_heard];
+    if (!s->used) return -1;
+    if (now_us <= s->last_rx_us) return -1;
+    uint64_t reply = now_us - s->last_rx_us;
+    if (reply > 0xFFFFFFFFull) return -1;   // too stale to echo
+    *echo_node = s->node_id;
+    *echo_seq = s->last_peer_seq;
+    *t_reply_us = (uint32_t)reply;
+    return g_last_heard;
+}
+
+uint32_t node_store_count(void) { return g_count; }
+
+const node_slot_t *node_store_slot(uint32_t index) {
+    if (index >= NODE_STORE_MAX) return NULL;
+    if (!g_slots[index].used) return NULL;
+    return &g_slots[index];
+}
+
+void node_store_stats_uart(void) {
+    dbg_puts("NODE peers=");
+    dbg_putu32(g_count);
+    dbg_putc('\n');
+}
+
+void node_store_list_uart(void) {
+    uint32_t lock = dbg_line_lock();
+    dbg_puts("=== node peers ===\n");
+    node_store_stats_uart();
+    if (g_count == 0) dbg_puts("(none)\n");
+    for (uint32_t i = 0; i < NODE_STORE_MAX; i++) {
+        const node_slot_t *s = &g_slots[i];
+        if (!s->used) continue;
+        dbg_puts("NODE id=");
+        dbg_putu32(s->node_id);
+        dbg_puts(" rx=");
+        dbg_putu32(s->rx_count);
+        dbg_puts(" q=");
+        put_f2(s->corr_q);
+        if (s->rng_valid) {
+            dbg_puts(" dist_m=");
+            put_f2(s->distance_m);
+            dbg_puts(" offset_us=");
+            put_i64(s->clock_offset_us);
+        } else {
+            dbg_puts(" dist=?");
+        }
+        dbg_puts(" synced=");
+        dbg_puts(s->synced ? "1" : "0");
+        dbg_putc('\n');
+    }
+    dbg_puts("=== end node peers ===\n");
+    dbg_line_unlock(lock);
+}

--- a/node_store.h
+++ b/node_store.h
@@ -1,0 +1,54 @@
+// node_store.h — peer table + acoustic two-way ranging / clock offset.
+//
+// Fed by acoustic_link on every decoded BEACON. Holds, per neighbour node:
+// distance (single-sided two-way ranging), clock offset, correlation quality,
+// and last-seen time. RAM-only (bounded); no flash dependency.
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#define NODE_STORE_MAX 8u
+
+typedef struct {
+    uint8_t  used;
+    uint8_t  node_id;
+    uint8_t  rng_valid;      // distance_m is meaningful
+    uint8_t  synced;         // peer advertised a synced clock
+    float    distance_m;     // SS-TWR estimate
+    float    corr_q;         // last correlation quality 0..1
+    int64_t  clock_offset_us;// our_clock - peer_clock (approx)
+    uint32_t rx_count;       // beacons heard from this peer
+    uint64_t last_rx_us;     // local time of last beacon
+    uint8_t  last_peer_seq;  // sender's last frame seq (for echoing back)
+} node_slot_t;
+
+void node_store_init(void);
+
+// Record that we transmitted a beacon (poll) with this seq at this local time.
+void node_store_note_tx(uint8_t seq, uint64_t tx_time_us);
+
+// Process a decoded BEACON from peer_id received locally at rx_time_us.
+//   peer_seq        : sender's own frame seq (so we can echo it back)
+//   peer_tx_mono_us : sender monotonic microseconds (low 32, from payload)
+//   echo_node       : peer's echoed target node id (0xFF = none)
+//   echo_seq        : echoed seq (matches our poll seq when echo_node == us)
+//   t_reply_us      : responder turnaround (t3 - t2) for SS-TWR
+//   corr_q          : matched-filter quality
+//   c_sound_m_s     : current speed of sound (baro-corrected)
+void node_store_on_beacon(uint8_t self_id, uint8_t peer_id, uint8_t peer_seq,
+                          uint64_t rx_time_us,
+                          uint32_t peer_tx_mono_us,
+                          uint8_t echo_node, uint8_t echo_seq,
+                          uint32_t t_reply_us,
+                          bool peer_synced,
+                          float corr_q, float c_sound_m_s);
+
+// If we heard peer_id, return its slot index and the turnaround we owe it
+// (rx->tx delta) so our next beacon can echo it. Returns -1 if none pending.
+int node_store_pending_echo(uint8_t *echo_node, uint8_t *echo_seq,
+                            uint32_t *t_reply_us, uint64_t now_us);
+
+uint32_t node_store_count(void);
+const node_slot_t *node_store_slot(uint32_t index);
+void node_store_list_uart(void);
+void node_store_stats_uart(void);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements the acoustic node-link plan: a collision-resistant node-to-node control plane over the existing **GP6/GP7 4 kHz PS1240 piezo** (TX) and the **6-mic 48 kHz array** (RX). No malloc / no blocking in the realtime path.

- **PHY (`acoustic_link.c` + `buzzer.c`)** — DSSS-BPSK on the existing beacon engine. Per-node **length-127 Gold codes** (CDMA). `buzzer.c` gains a chip-stream TX API (`buzzer_tx_chips`); the periodic PN beacon resumes when idle.
- **MAC / SEC** — fixed 31-byte frame with **Hamming(7,4) FEC + CRC32** and reserved `key_id`/`nonce`/`encrypted` fields; crypto is a no-op **AEAD-ready stub** today.
- **RX** — mono mix tapped in `build_usb_frame_from_i2s()`; a bounded **matched filter** (I/Q downconvert → per-chip integrate → Gold-code correlation → phase-derotated despread) runs in `acoustic_link_poll()`.
- **Ranging (`node_store.c`)** — single-sided **two-way ranging** using the baro-corrected speed of sound (`doa_c_sound_m_s()`); per-peer distance, clock offset, quality, last-seen.
- **Time sync** — new `HET68_TIME_SRC_ACOUSTIC`; an unsynced node adopts a synced peer's epoch from `BEACON` frames.
- **Wi-Fi wake / OTA** — `CTRL WIFI_WAKE` flags a Wi-Fi bring-up for bulk sync / OTA on CYW43 boards (guarded by `HET68_WIFI_WAKE`; stub on `pico2`).
- **CLI** — `LINK`, `LINK ID <0-7>`, `LINK BEACON`, `LINK WIFI`; link + peer/ranging stats added to `STATUS` and the boot dump.
- **Collision handling** — CDMA code separation + randomized beacon jitter (slotted-ALOHA-ish) + listen-before-talk on our own PHY.
- Version bumped to **1.3.0**.

## Requirements mapping
- Uses existing pins **GP6/GP7** and the **4 kHz** method (as requested).
- Room for expansion: `BEACON` / `DETECT` / `CTRL` frame types; reserved crypto fields.
- Error protection: **CRC32 + Hamming(7,4) FEC**.
- Future encryption: `encrypted` flag + `key_id`/`nonce` with `crypto_seal`/`crypto_open` hooks.
- Wi-Fi trigger for larger data / firmware upgrade.

## Build / test
- [x] `PICO_BOARD=pico2 ./build.sh`
- [x] `PICO_BOARD=pico2_w ./build.sh` (CYW43 / Wi-Fi-wake path)
- [x] `PICO_BOARD=pimoroni_pico_plus2_w_rp2350 ./build.sh`
- Only warnings are pre-existing vendored btstack `-Wstringop-overflow`.
- Not hardware-validated: over-air acquisition thresholds, ToA precision, and Gold preferred-pair optimality are best-effort and will need bench tuning. Actual Wi-Fi STA connect + AEAD are intentionally left as stubs behind the wired-in hooks.

## Notes
- Stealth is best-effort (spread spectrum + low duty), not true inaudibility, since the PS1240 resonates at 4 kHz (per the chosen trade-off).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

