### PR TITLE
docs: bilingual wiki (UART FAQ, chirp frame, architecture)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,9 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   sync / OTA on CYW43 boards. Collisions are handled by CDMA code separation plus
   randomized beacon jitter. Stealth is best-effort (spread spectrum + low duty),
   not true inaudibility, since the PS1240 resonates at 4 kHz. UART: `LINK`,
-  `LINK ID <0-7>`, `LINK BEACON`, `LINK WIFI`. Full protocol docs:
-  [`chirp.md`](chirp.md) (English) / [`chirp.cs.md`](chirp.cs.md) (Čeština);
+  `LINK ID <0-7>`, `LINK BEACON`, `LINK WIFI`. Understanding + FAQ:
+  [`wiki.md`](wiki.md) (English) / [`wiki.cs.md`](wiki.cs.md) (Čeština).
+  Full protocol docs: [`chirp.md`](chirp.md) / [`chirp.cs.md`](chirp.cs.md);
   see also [`acoustic_link.h`](acoustic_link.h) / [`node_store.h`](node_store.h).
 
 * **OpenDroneID / EU Direct Remote ID (v1.1.0+).** On CYW43 boards

--- a/chirp.cs.md
+++ b/chirp.cs.md
@@ -7,6 +7,9 @@ a měří vzájemnou vzdálenost přes palubní **4 kHz piezo PS1240** (GP6/GP7)
 **pole 6 mikrofonů se vzorkováním 48 kHz** — spojení "chirp" zavedené ve firmwaru
 **v1.3.0** ([`acoustic_link.c`](acoustic_link.c), [`node_store.c`](node_store.c)).
 
+Kratší přehled formou FAQ (UART logování, variabilita rámce, zasazení do
+zbytku firmware): [`wiki.cs.md`](wiki.cs.md) / [`wiki.md`](wiki.md).
+
 - Cíle návrhu: odolnost vůči kolizím při provozu více nodů, vzájemná
   synchronizace času, vzájemné měření vzdálenosti, dobrý dosah a co nejmenší
   postřehnutelnost pro lidské ucho.

--- a/chirp.md
+++ b/chirp.md
@@ -7,6 +7,10 @@ clocks, and measure mutual distance over the on-board **4 kHz PS1240 piezo**
 (GP6/GP7) plus the **6-microphone 48 kHz array** — the "chirp" link introduced in
 firmware **v1.3.0** ([`acoustic_link.c`](acoustic_link.c), [`node_store.c`](node_store.c)).
 
+For a shorter FAQ-oriented overview (UART logging, frame variability, how the
+link fits the rest of the firmware), see [`wiki.md`](wiki.md) /
+[`wiki.cs.md`](wiki.cs.md).
+
 - Design goals: collision-resistant multi-node operation, mutual time sync,
   mutual ranging, good range, and minimal audibility.
 - Constraints (see [`AGENTS.md`](AGENTS.md)): no `malloc`/`free` in the realtime

--- a/wiki.cs.md
+++ b/wiki.cs.md
@@ -1,0 +1,300 @@
+# het68 wiki — pochopení současného firmware
+
+Jazyk: **Čeština** · [English](wiki.md)
+
+Tato wiki vysvětluje **současné** řešení het68 na větvi `main`
+(akustický node link **v1.3.x** a související subsystémy). Rozšiřuje praktické
+otázky kolem UART logů a formátu chirp zpráv a zasazuje je do zbytku stacku.
+
+Úplná protokolová reference (PHY, ranging, MAC, air-time):
+[`chirp.cs.md`](chirp.cs.md) / [`chirp.md`](chirp.md).
+Přehled projektu a build: [`README.md`](README.md), [`BUILDING.md`](BUILDING.md).
+
+---
+
+## 1. Co firmware je
+
+het68 je USB audio firmware pro Raspberry Pi Pico / Pico 2 (RP2040 / RP2350):
+
+| Role | Co dělá |
+|---|---|
+| USB UAC2 zvukovka | 6kanálový vstup mikrofonů 48 kHz ze 3× stereo I2S (PIO + DMA + TinyUSB) |
+| Akustický front-end | On-device DOA / klasifikace (dron, ptáci, vozidla, …) bez host PC |
+| Baro + rychlost zvuku | Grove DPS310 (GP2/GP3 I2C1) → vlhký vzduch \(c(T,p,\mathrm{RH})\) pro DOA i ranging |
+| Časová základna | `TIME` / `TIME INFO` se zdroji `uart`, `rid`, `acoustic` |
+| Remote ID | BLE OpenDroneID sken na deskách s CYW43 |
+| Node link („chirp“) | Objev sousedů, hrubá sync hodin, vzájemný ranging přes piezo 4 kHz |
+
+Tvrdá omezení ([`AGENTS.md`](AGENTS.md)): žádné `malloc`/`free` v realtime
+audio cestě; žádné blokování v IRQ / DMA / USB callbackách; držet PIO, DMA a
+USB frame velikosti konzistentní.
+
+---
+
+## 2. Velký obrázek — jak se části propojují
+
+```mermaid
+flowchart TB
+  subgraph sense [Snímání]
+    mics["6 miků @ 48 kHz I2S"]
+    baro["DPS310 T/p (+ RH CLI)"]
+    ble["BLE RID sken CYW43"]
+  end
+  subgraph core [Core0 main loop]
+    usb["USB UAC2 frames"]
+    doa["DOA + klasifikace"]
+    alink["acoustic_link_poll"]
+    time["het68_time"]
+    cli["UART CLI"]
+  end
+  subgraph air [Akustický node link]
+    piezo["PS1240 GP6/GP7 DSSS-BPSK"]
+    peers["node_store peers / dist / offset"]
+  end
+  mics --> usb
+  mics --> doa
+  mics -->|"mono mix"| alink
+  baro --> doa
+  baro -->|"c zvuku"| peers
+  ble --> time
+  piezo <-->|"vzduch 4 kHz"| alink
+  alink --> peers
+  alink -->|"převzetí epochy"| time
+  doa --> cli
+  peers --> cli
+  time --> cli
+```
+
+- **TX chirp:** APP rámec → CRC32 + Hamming(7,4) → Gold CDMA čipy →
+  `buzzer_tx_chips()` na GP6/GP7.
+- **RX chirp:** šest miků smícháno do mono v `build_usb_frame_from_i2s()` →
+  `acoustic_link_rx_push()` (levný ring) → matched filter v
+  `acoustic_link_poll()` (ohraničeně, main loop).
+- **Ranging / peery:** každý platný `BEACON` aktualizuje
+  [`node_store`](node_store.c); vzdálenost používá `doa_c_sound_m_s()`.
+
+Poznámka k pinům: **GP2/GP3 = DPS310 I2C**, **GP6/GP7 = piezo**. Neměnit mapování
+bez aktualizace dokumentace ([`wiring_and_bom.md`](wiring_and_bom.md)).
+
+---
+
+## 3. FAQ — UART: co ze souseda se loguje?
+
+### Krátká odpověď
+
+Při **automatickém příjmu** se na UART vypíše jen několik typů rámců. Úspěšné
+**BEACONy ne**. Jejich obsah zůstává v RAM a ukáže se na vyžádání přes
+`LINK` / `STATUS`.
+
+### Automatické UART řádky (RX / boot)
+
+| Událost | Typický UART řádek | Poznámka |
+|---|---|---|
+| Boot / init | `LINK: acoustic node link … node=` | Jednou při startu |
+| Rámec `DETECT` | `LINK DETECT from=<id> cls=<n>` | Peer id + bajt třídy |
+| `CTRL` `WIFI_WAKE` | `LINK: WIFI_WAKE token=…` nebo „no Wi-Fi…“ | Nastaví i wake-pending flag |
+| `CTRL` `OTA_REQ` | `LINK: OTA_REQ received` | Placeholder; OTA přenos ještě není |
+| `BEACON` | *(nic)* | Update `node_store`; může **tiše** volat `het68_time_sync_from(..., ACOUSTIC)` |
+
+Tedy: ranging pole, epocha, echo/SS-TWR data, kvalita korelace a tabulka peerů
+se **nepíšou** při každém dekódu.
+
+### UART na vyžádání (`LINK`, `STATUS`, boot dump)
+
+`acoustic_link_status_uart()` a pak `node_store_list_uart()`:
+
+```
+LINK node=<id> tx=<n> rx=<n> bad_crc=<n> peers=<n> wifi_wake=<0|1>
+=== node peers ===
+NODE id=<id> rx=<n> q=<0.xx> dist_m=<m>|dist=? offset_us=<…> synced=<0|1>
+…
+```
+
+| Pole | Význam |
+|---|---|
+| `tx` / `rx` / `bad_crc` | Lokální počítadla linku |
+| `peers` | Obsazené sloty v `node_store` (max 8) |
+| `q` | Poslední kvalita matched filtru \(0..1\) |
+| `dist_m` | SS-TWR vzdálenost po platném echu; jinak `dist=?` |
+| `offset_us` | Hrubý `our_clock − peer_clock` ze stejné výměny |
+| `synced` | Peer inzeroval `ALINK_FLAG_SYNCED` |
+
+CLI: `LINK`, `LINK ID <0-7>`, `LINK BEACON`, `LINK WIFI` — viz [`cli.c`](cli.c).
+
+### Proč je BEACON tichý
+
+Maják trvá ~7,2 s na vzduchu a opakuje se často. Logovat každý dekód by
+zaplavilo UART a překrylo DET/RID/CMP provoz. Návrh: **tiché uložení +
+explicitní dump**.
+
+---
+
+## 4. FAQ — struktura chirp zprávy a její variabilita
+
+### Pevná velikost na vzduchu (vždy)
+
+Každý rámec je **pevných 31 bajtů** plaintextu před FEC a pak vždy stejná
+zakódovaná délka. Velikost RX zůstává konstantní.
+
+| Offset | Pole | Bajtů |
+|---|---|---|
+| 0 | `version` (`ALINK_VERSION` = 1) | 1 |
+| 1 | `node_id` (odesílatel, 0..7) | 1 |
+| 2 | `type` | 1 |
+| 3 | `seq` | 1 |
+| 4 | `flags` | 1 |
+| 5 | `key_id` (crypto, rezervováno) | 1 |
+| 6..9 | `nonce` LE32 (crypto, rezervováno) | 4 |
+| 10 | `len` (logická délka payloadu 0..16) | 1 |
+| 11..26 | `payload` (vždy doplněno na 16) | 16 |
+| 27..30 | CRC32 LE přes bajty 0..26 | 4 |
+
+Pak: Hamming(7,4) → **434** kódovaných bitů → DSSS SF=8 → **3472** datových
+čipů + **127** preambulí = **3599** čipů ≈ **7,2 s** při 500 čip/s.
+
+### Co se skutečně mění
+
+Variabilita je **sémantická**, ne délková:
+
+1. **`type`** — `BEACON=0`, `DETECT=1`, `CTRL=2`, `ACK=3`
+2. **`flags`** — `ENCRYPTED` (0x01, stub), `ACK_REQ` (0x02), `SYNCED` (0x04)
+3. **`seq`**, **`node_id`**, počítadla / časová razítka v payloadu
+4. **CDMA kód** — podle `node_id` odesílatele (Gold rodina); není pole v payloadu
+5. **`len`** — deklarováno 0..16, TX ale stejně paduje 16bajtový slot
+
+Co se **nemění**: počet bajtů rámce, kódovaných bitů, čipů, nosná (4 kHz),
+čipová rychlost, spreading factor.
+
+### Layouty payloadu (uvnitř pevných 16 B)
+
+**BEACON** (periodický scheduler + `LINK BEACON`):
+
+| Off | Obsah |
+|---|---|
+| 0..3 | `tx_mono` LE32 — monotonic µs odesílatele (low 32) |
+| 4..7 | Unix epocha LE32 — `0` pokud není sync |
+| 8 | `echo_node` — id peeru pro SS-TWR, nebo `0xFF` |
+| 9..12 | `t_reply` LE32 — turnaround \(t_3 - t_2\) |
+| 13 | `echo_seq` — seq pollu, který se echo-uje |
+| 14 | synced bajt `0/1` |
+| 15 | padding |
+
+**DETECT:** kompaktní souhrn; UART bere `payload[0]` jako `cls` + `node_id` z hlavičky.
+
+**CTRL:** `payload[0]` = subtype (`WIFI_WAKE=1`, `OTA_REQ=2`); u wake
+`payload[1]` = rendezvous token.
+
+**Crypto:** `key_id` / `nonce` / `ENCRYPTED` jsou na drátě; `crypto_seal` /
+`crypto_open` jsou identity stuby — zapnutí AEAD později nevyžaduje změnu
+velikosti rámce.
+
+---
+
+## 5. Ranging a čas (co BEACON přináší)
+
+### Single-sided two-way ranging (SS-TWR)
+
+Broadcast majáky slouží i jako ranging pakety ([`node_store.c`](node_store.c)):
+
+1. **A** pošle maják `seqA` v \(t_1\) (hodiny A); zapamatuje \((seqA, t_1)\).
+2. **B** uslyší v \(t_2\); další maják echo-uje `{A, seqA, t_\mathrm{reply}=t_3-t_2}`.
+3. **A** uslyší B v \(t_4\); \(\mathrm{ToF}=(t_4-t_1 - t_\mathrm{reply})/2\);
+   \(\mathrm{vzdálenost} = \mathrm{ToF} \cdot c\).
+
+\(c\) bere barometrický model vlhkého vzduchu (`doa_c_sound_m_s()`). Sanity:
+\(0 \le \mathrm{ToF} < 600\,\mathrm{ms}\) (~200 m).
+
+Hrubý offset hodin: \(\mathrm{offset}(A-B) = t_4 - t_3 - \mathrm{ToF}\)
+(\(t_3\) nesen jako peer TX mono v payloadu).
+
+### Úrovně synchronizace času
+
+| Úroveň | Mechanismus | Viditelné jako |
+|---|---|---|
+| Hrubá epocha | Nesync node převezme epochu peeru s `SYNCED` | `TIME INFO` zdroj `acoustic`, quality 60 |
+| Jemný offset | Per-peer `clock_offset_us` z SS-TWR | `NODE … offset_us=` v `LINK` |
+
+Akustická quality je záměrně nižší než UART/RID, aby přímý zdroj vyhrál.
+
+---
+
+## 6. Vícenásobný přístup, rychlost a slyšitelnost
+
+- **CDMA:** až 8 Gold kódů (`ALINK_MAX_NODES`); korelátor bere nejsilnější
+  shodu preambule (`rho > 0.30` + energetický práh).
+- **Slotted-ALOHA jitter:** základ majáku ~1500 ms + 0..500 ms náhodně; plus
+  listen-before-talk (`buzzer_tx_busy()`).
+- **Propustnost:** ~31 info bajtů / ~7,2 s ≈ **34 bit/s** — jen řídicí/ranging
+  rovina. Bulk / OTA → `WIFI_WAKE` a pak Wi-Fi (STA cesta je zatím odložená).
+- **Slyšitelnost:** 4 kHz je v citlivém pásmu sluchu; spread spectrum + nízký
+  duty cyklus dávají spíš „slabé kliky/šum“, ne ticho.
+
+Kompromisy pro rychlejší link (budoucnost): nižší `ALINK_DATA_SF`, kratší rámec
+nebo vyšší čipová rychlost (`ALINK_CYCLES_CHIP`).
+
+---
+
+## 7. Související subsystémy (kontext celého řešení)
+
+### DOA / klasifikace
+
+Běží na stejném 48kHz streamu jako USB a chirp RX. Třídy a DET log / entity
+persistence ovládá CLI (`DET`, `ENT`, `DRONE`, …). CMP řádky mohou slučovat
+akustické DOA s RID GPS.
+
+### Barometr a \(c\)
+
+DPS310 na I2C1; CLI `BARO` / `BARO RH`. Rychlost zvuku živí geometrii DOA i
+akustický ranging, aby \(T/p/\mathrm{RH}\) odpovídaly podmínkám venku.
+
+### Remote ID
+
+Na wireless deskách BLE ODID → tracky + volitelná sync času ze System zpráv.
+Flash store známých dronů a dump ve `STATUS` je oddělený od chirp peer tabulky
+(RAM-only `node_store`).
+
+### Wi-Fi wake
+
+Akustický `CTRL WIFI_WAKE` nastaví `acoustic_link_wifi_wake_pending()`. Desky
+CYW43 kompilují bring-up hook; bez Wi-Fi jen logují. Skutečné STA + OTA je
+následná aplikační práce (credentials + koexistence s BTstack).
+
+---
+
+## 8. Praktický checklist operátora
+
+1. Nahraj UF2 **v1.3.x** pro svou desku; otevři debug UART.
+2. Nastav unikátní id: `LINK ID <0-7>` (nebo `HET68_NODE_ID=n ./build.sh`).
+3. Volitelně: `TIME SYNC` / počkej na RID nebo akustickou epochu; zkontroluj
+   `TIME INFO`.
+4. Volitelně: `BARO` / `BARO RH`, ať je \(c\) (a tedy `dist_m`) rozumné.
+5. Automatické řádky sleduj u `DETECT` / `WIFI_WAKE`; peery a vzdálenost přes
+   `LINK`.
+6. Vynutit rámec: `LINK BEACON` nebo `LINK WIFI`.
+
+Protokol do hloubky: [`chirp.cs.md`](chirp.cs.md). Zdroje: `acoustic_link.*`,
+`node_store.*`, `buzzer.*`, `het68_time.*`, `main.c`, `cli.c`.
+
+---
+
+## 9. Známá omezení (upřímný snapshot)
+
+- Není plně ověřeno na hardwaru (práh, Gold pár, přesnost ToA).
+- ToA je dnes v **rozlišení čipu** (~2 ms ≈ 0,69 m při \(c \approx 343\,\mathrm{m/s}\));
+  sub-chip interpolace peaku by ranging zpřesnila.
+- SS-TWR ≠ double-sided TWR (rušení skew není kompletní).
+- Crypto a Wi-Fi OTA jsou hooky/stuby, ne end-to-end funkce.
+- BEACON RX záměrně nejde na UART — peery prohlížej přes `LINK`.
+
+---
+
+## 10. Mapa dokumentace
+
+| Dokument | Jazyk | Role |
+|---|---|---|
+| [`wiki.md`](wiki.md) / [`wiki.cs.md`](wiki.cs.md) | EN / CS | Pochopení + FAQ (tato stránka) |
+| [`chirp.md`](chirp.md) / [`chirp.cs.md`](chirp.cs.md) | EN / CS | Úplný akustický protokol |
+| [`README.md`](README.md) | EN | Přehled produktu, CLI, releasy |
+| [`BUILDING.md`](BUILDING.md) | EN | Build / desky |
+| [`wiring_and_bom.md`](wiring_and_bom.md) | EN | Piny / BOM |
+| [`AGENTS.md`](AGENTS.md) | EN | Tvrdá pravidla firmware pro přispěvatele |

--- a/wiki.md
+++ b/wiki.md
@@ -1,0 +1,299 @@
+# het68 wiki — understanding the current firmware
+
+Language: **English** · [Čeština](wiki.cs.md)
+
+This wiki explains the **current** het68 solution as shipped on `main`
+(acoustic node link **v1.3.x** and related subsystems). It expands the practical
+questions that come up when reading UART logs and the chirp wire format, and
+ties them into the rest of the stack.
+
+For the full protocol reference (PHY parameters, ranging math, MAC, air-time
+budget), see [`chirp.md`](chirp.md) / [`chirp.cs.md`](chirp.cs.md).
+Project overview and build: [`README.md`](README.md), [`BUILDING.md`](BUILDING.md).
+
+---
+
+## 1. What the firmware is
+
+het68 is Raspberry Pi Pico / Pico 2 USB audio firmware (RP2040 / RP2350):
+
+| Role | What it does |
+|---|---|
+| USB UAC2 sound card | 6-channel mic input at 48 kHz from 3× stereo I2S pairs (PIO + DMA + TinyUSB) |
+| Acoustic front-end | On-device DOA / classify (drone, birds, vehicles, …) without a host PC |
+| Baro + speed of sound | Grove DPS310 (GP2/GP3 I2C1) → moist-air \(c(T,p,\mathrm{RH})\) for DOA and ranging |
+| Time base | `TIME` / `TIME INFO` with sources `uart`, `rid`, `acoustic` |
+| Remote ID | BLE OpenDroneID scan on CYW43 boards |
+| Node link (“chirp”) | Neighbour discovery, coarse clock sync, mutual ranging over the 4 kHz piezo |
+
+Hard constraints ([`AGENTS.md`](AGENTS.md)): no `malloc`/`free` in the realtime
+audio path; no blocking in IRQ / DMA / USB callbacks; keep PIO, DMA and USB
+frame sizes consistent.
+
+---
+
+## 2. Big picture — how pieces connect
+
+```mermaid
+flowchart TB
+  subgraph sense [Sensing]
+    mics["6 mics @ 48 kHz I2S"]
+    baro["DPS310 T/p (+ RH CLI)"]
+    ble["BLE RID scan CYW43"]
+  end
+  subgraph core [Core0 main loop]
+    usb["USB UAC2 frames"]
+    doa["DOA + classify"]
+    alink["acoustic_link_poll"]
+    time["het68_time"]
+    cli["UART CLI"]
+  end
+  subgraph air [Acoustic node link]
+    piezo["PS1240 GP6/GP7 DSSS-BPSK"]
+    peers["node_store peers / dist / offset"]
+  end
+  mics --> usb
+  mics --> doa
+  mics -->|"mono mix"| alink
+  baro --> doa
+  baro -->|"c sound"| peers
+  ble --> time
+  piezo <-->|"air 4 kHz"| alink
+  alink --> peers
+  alink -->|"epoch adopt"| time
+  doa --> cli
+  peers --> cli
+  time --> cli
+```
+
+- **TX path for chirp:** APP frame → CRC32 + Hamming(7,4) → Gold CDMA chips →
+  `buzzer_tx_chips()` on GP6/GP7.
+- **RX path for chirp:** six mics mixed to mono inside `build_usb_frame_from_i2s()`
+  → `acoustic_link_rx_push()` (cheap ring) → matched filter in
+  `acoustic_link_poll()` (bounded, main loop).
+- **Ranging / peers:** every valid `BEACON` updates [`node_store`](node_store.c);
+  distance uses `doa_c_sound_m_s()`.
+
+Pin note: **GP2/GP3 = DPS310 I2C**, **GP6/GP7 = piezo**. Do not remap without
+updating docs ([`wiring_and_bom.md`](wiring_and_bom.md)).
+
+---
+
+## 3. FAQ — UART: what neighbour info is logged?
+
+### Short answer
+
+On **automatic receive**, only a few frame types print a line. Successful
+**BEACONs do not**. Their content is stored in RAM and shown on demand via
+`LINK` / `STATUS`.
+
+### Automatic UART lines (RX / boot)
+
+| Event | Typical UART line | Notes |
+|---|---|---|
+| Boot / init | `LINK: acoustic node link … node=` | Once at bring-up |
+| `DETECT` frame | `LINK DETECT from=<id> cls=<n>` | Logs peer id + class byte |
+| `CTRL` `WIFI_WAKE` | `LINK: WIFI_WAKE token=…` or “no Wi-Fi on this board” | Also sets wake-pending flag |
+| `CTRL` `OTA_REQ` | `LINK: OTA_REQ received` | Placeholder; no OTA transfer yet |
+| `BEACON` | *(none)* | Updates `node_store`; may call `het68_time_sync_from(..., ACOUSTIC)` **silently** |
+
+So: ranging fields, epoch, echo/SS-TWR data, correlation quality, and peer
+tables are **not** spammed on every decode.
+
+### On-demand UART (`LINK`, `STATUS`, boot dump)
+
+`acoustic_link_status_uart()` then `node_store_list_uart()`:
+
+```
+LINK node=<id> tx=<n> rx=<n> bad_crc=<n> peers=<n> wifi_wake=<0|1>
+=== node peers ===
+NODE id=<id> rx=<n> q=<0.xx> dist_m=<m>|dist=? offset_us=<…> synced=<0|1>
+…
+```
+
+| Field | Meaning |
+|---|---|
+| `tx` / `rx` / `bad_crc` | Local link counters |
+| `peers` | Occupied slots in `node_store` (max 8) |
+| `q` | Last matched-filter quality \(0..1\) |
+| `dist_m` | SS-TWR distance when a valid echo completed; else `dist=?` |
+| `offset_us` | Coarse `our_clock − peer_clock` from the same exchange |
+| `synced` | Peer advertised `ALINK_FLAG_SYNCED` |
+
+CLI: `LINK`, `LINK ID <0-7>`, `LINK BEACON`, `LINK WIFI` — see [`cli.c`](cli.c).
+
+### Why BEACON is quiet
+
+A beacon is ~7.2 s on air and repeats often. Logging every decode would flood
+UART and hide DET/RID/CMP traffic. The design is: **silent store + explicit
+dump**.
+
+---
+
+## 4. FAQ — chirp message structure and variability
+
+### Fixed on-air size (always)
+
+Every frame is a **fixed 31-byte plaintext** before FEC, then always the same
+coded length on the air. RX sizing stays constant.
+
+| Offset | Field | Bytes |
+|---|---|---|
+| 0 | `version` (`ALINK_VERSION` = 1) | 1 |
+| 1 | `node_id` (sender, 0..7) | 1 |
+| 2 | `type` | 1 |
+| 3 | `seq` | 1 |
+| 4 | `flags` | 1 |
+| 5 | `key_id` (crypto reserved) | 1 |
+| 6..9 | `nonce` LE32 (crypto reserved) | 4 |
+| 10 | `len` (logical payload length 0..16) | 1 |
+| 11..26 | `payload` (always padded to 16) | 16 |
+| 27..30 | CRC32 LE over bytes 0..26 | 4 |
+
+Then: Hamming(7,4) → **434** coded bits → DSSS SF=8 → **3472** data chips +
+**127** preamble chips = **3599** chips ≈ **7.2 s** at 500 chip/s.
+
+### What actually varies
+
+Variability is **semantic**, not length:
+
+1. **`type`** — `BEACON=0`, `DETECT=1`, `CTRL=2`, `ACK=3`
+2. **`flags`** — `ENCRYPTED` (0x01, stub), `ACK_REQ` (0x02), `SYNCED` (0x04)
+3. **`seq`**, **`node_id`**, counters / timestamps inside payload
+4. **CDMA code** — chosen by sender `node_id` (Gold family); not a payload field
+5. **`len`** — declared 0..16, but TX still pads the 16-byte payload slot
+
+What does **not** vary today: frame byte count, coded bit count, chip count,
+carrier (4 kHz), chip rate, spreading factor.
+
+### Payload layouts (inside the fixed 16 B)
+
+**BEACON** (periodic scheduler + `LINK BEACON`):
+
+| Off | Content |
+|---|---|
+| 0..3 | `tx_mono` LE32 — sender monotonic µs (low 32) at schedule time |
+| 4..7 | Unix epoch LE32 — `0` if not synced |
+| 8 | `echo_node` — peer id being answered for SS-TWR, or `0xFF` |
+| 9..12 | `t_reply` LE32 — turnaround \(t_3 - t_2\) |
+| 13 | `echo_seq` — seq of the poll being echoed |
+| 14 | synced byte `0/1` (mirrors header flag intent) |
+| 15 | padding |
+
+**DETECT:** compact summary; UART uses `payload[0]` as `cls` plus header `node_id`.
+
+**CTRL:** `payload[0]` = subtype (`WIFI_WAKE=1`, `OTA_REQ=2`); for wake,
+`payload[1]` = rendezvous token.
+
+**Crypto:** `key_id` / `nonce` / `ENCRYPTED` are on the wire; `crypto_seal` /
+`crypto_open` are identity stubs — enabling AEAD later needs no frame resize.
+
+---
+
+## 5. Ranging and time (what a BEACON buys you)
+
+### Single-sided two-way ranging (SS-TWR)
+
+Broadcast beacons double as ranging packets ([`node_store.c`](node_store.c)):
+
+1. **A** sends beacon `seqA` at \(t_1\) (A clock); remembers \((seqA, t_1)\).
+2. **B** hears it at \(t_2\); next beacon echoes `{A, seqA, t_\mathrm{reply}=t_3-t_2}`.
+3. **A** hears B at \(t_4\); \(\mathrm{ToF}=(t_4-t_1 - t_\mathrm{reply})/2\);
+   \(\mathrm{distance} = \mathrm{ToF} \cdot c\).
+
+\(c\) comes from the baro moist-air model (`doa_c_sound_m_s()`). Sanity gate:
+\(0 \le \mathrm{ToF} < 600\,\mathrm{ms}\) (~200 m).
+
+Coarse clock offset: \(\mathrm{offset}(A-B) = t_4 - t_3 - \mathrm{ToF}\)
+(with \(t_3\) carried as peer TX mono in the payload).
+
+### Time sync levels
+
+| Level | Mechanism | Visible as |
+|---|---|---|
+| Coarse epoch | Unsynced node adopts peer epoch when peer has `SYNCED` | `TIME INFO` source `acoustic`, quality 60 |
+| Fine offset | Per-peer `clock_offset_us` from SS-TWR | `NODE … offset_us=` in `LINK` |
+
+Acoustic quality is intentionally below UART/RID so a direct source wins.
+
+---
+
+## 6. Multiple access, rate, and audibility
+
+- **CDMA:** up to 8 Gold codes (`ALINK_MAX_NODES`); correlator picks strongest
+  preamble match (`rho > 0.30` + energy gate).
+- **Slotted-ALOHA jitter:** beacon base ~1500 ms + 0..500 ms random; plus
+  listen-before-talk (`buzzer_tx_busy()`).
+- **Throughput:** ~31 info bytes / ~7.2 s ≈ **34 bit/s** — control/ranging plane
+  only. Bulk / OTA → `WIFI_WAKE` then Wi-Fi (STA path still deferred).
+- **Audibility:** 4 kHz is in the sensitive hearing band; spread spectrum + low
+  duty make it “faint clicks/hiss”, not silent.
+
+Trade-offs for a faster link (future): lower `ALINK_DATA_SF`, shorter frame, or
+higher chip rate (`ALINK_CYCLES_CHIP`).
+
+---
+
+## 7. Related subsystems (current solution context)
+
+### DOA / classify
+
+Runs on the same 48 kHz mic stream as USB and chirp RX. Classes and DET log /
+entity persistence are CLI-driven (`DET`, `ENT`, `DRONE`, …). CMP lines can fuse
+acoustic DOA with RID GPS when both exist.
+
+### Barometer and \(c\)
+
+DPS310 on I2C1; CLI `BARO` / `BARO RH`. Speed of sound feeds both DOA geometry
+and acoustic ranging so temperature/pressure/humidity track outdoor conditions.
+
+### Remote ID
+
+On wireless boards, BLE ODID → tracks + optional time sync from System messages.
+Known-drone flash store and `STATUS` flash dump are separate from the chirp peer
+table (RAM-only `node_store`).
+
+### Wi-Fi wake
+
+Acoustic `CTRL WIFI_WAKE` sets `acoustic_link_wifi_wake_pending()`. CYW43 boards
+compile the bring-up hook; non-wireless boards only log. Actual STA + OTA is
+application follow-up work (credentials + coexistence with BTstack).
+
+---
+
+## 8. Practical operator checklist
+
+1. Flash a **v1.3.x** UF2 for your board; open debug UART.
+2. Set unique ids: `LINK ID <0-7>` (or `HET68_NODE_ID=n ./build.sh`).
+3. Optional: `TIME SYNC` / wait for RID or acoustic epoch; check `TIME INFO`.
+4. Optional: `BARO` / `BARO RH` so \(c\) (and thus `dist_m`) is sane.
+5. Watch automatic lines for `DETECT` / `WIFI_WAKE`; use `LINK` for peers and
+   distance.
+6. Force a frame: `LINK BEACON` or `LINK WIFI`.
+
+Deep protocol: [`chirp.md`](chirp.md). Sources: `acoustic_link.*`, `node_store.*`,
+`buzzer.*`, `het68_time.*`, `main.c`, `cli.c`.
+
+---
+
+## 9. Known limits (honest snapshot)
+
+- Not fully hardware-validated (thresholds, Gold pair, ToA accuracy).
+- ToA is **chip-resolution** today (~2 ms ≈ 0.69 m at \(c \approx 343\,\mathrm{m/s}\));
+  sub-chip peak interpolation would sharpen ranging.
+- SS-TWR ≠ double-sided TWR (skew cancellation incomplete).
+- Crypto and Wi-Fi OTA are hooks/stubs, not end-to-end features yet.
+- BEACON RX stays off the UART by design — use `LINK` to inspect peers.
+
+---
+
+## 10. Doc map
+
+| Doc | Language | Role |
+|---|---|---|
+| [`wiki.md`](wiki.md) / [`wiki.cs.md`](wiki.cs.md) | EN / CS | Understanding + FAQ (this page) |
+| [`chirp.md`](chirp.md) / [`chirp.cs.md`](chirp.cs.md) | EN / CS | Full acoustic-link protocol |
+| [`README.md`](README.md) | EN | Product overview, CLI, releases |
+| [`BUILDING.md`](BUILDING.md) | EN | Build / boards |
+| [`wiring_and_bom.md`](wiring_and_bom.md) | EN | Pins / BOM |
+| [`AGENTS.md`](AGENTS.md) | EN | Firmware hard rules for contributors |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds understanding-oriented wiki docs for the current het68 stack, focused on the acoustic node link questions that came up in review:

- What neighbour RX info is logged automatically on UART vs only via `LINK`/`STATUS`
- Fixed 31-byte chirp frame layout and what actually varies (type/flags/payload semantics, not air-time length)
- How chirp fits DOA, baro/\(c\), time sources, RID, and Wi-Fi wake
- Operator checklist and known limits

**Files**
- `wiki.md` (English) / `wiki.cs.md` (Čeština)
- Cross-links from `README.md`, `chirp.md`, `chirp.cs.md`

Docs only — no firmware change. Deep protocol reference remains in `chirp.md` / `chirp.cs.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

