### PR TITLE
1.4.0: fast FHSS chirp under 100 ms (PS1240)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(SRCS
 add_executable(pico_6mic_soundcard ${SRCS})
 
 # Version stamp (UART help / docs). Semver core for releases.
-add_compile_definitions(HET68_VERSION_STR=\"1.3.1\")
+add_compile_definitions(HET68_VERSION_STR=\"1.4.0\")
 
 # Optional fixed acoustic-link node id (0..7). Default 0; also settable at
 # runtime via the LINK ID CLI command.

--- a/README.md
+++ b/README.md
@@ -196,22 +196,16 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   `DET LIST|EXPORT|BACKUP|IMPORT|DEL|CLEAR`, `ENT LIST|EXPORT|IMPORT`,
   `DRONE LIST|CLEAR`, `BARO`, `LINK`, `RID LIST|ON|OFF`. See [`TEST_SCENARIOS_1.0.6.md`](TEST_SCENARIOS_1.0.6.md).
 
-* **Acoustic node link (v1.3.0+).** Nodes talk to each other over the existing
-  GP6/GP7 4 kHz PS1240 piezo using **DSSS-BPSK**: a per-node CDMA code
-  (length-127 Gold family) spreads a fixed frame carrying a **Hamming(7,4) FEC +
-  CRC32** payload, with reserved `key_id`/`nonce`/`encrypted` fields for future
-  AEAD. RX rides on the 6-mic 48 kHz capture (mono mix → matched filter). The
-  link does **single-sided two-way ranging** (mutual distance, using the
-  baro-corrected speed of sound), **coarse time sync** (an unsynced node adopts a
-  synced peer's epoch as `TIME` source `acoustic`), and carries `BEACON` /
-  `DETECT` / `CTRL` frames. `CTRL WIFI_WAKE` requests bringing up Wi-Fi for bulk
-  sync / OTA on CYW43 boards. Collisions are handled by CDMA code separation plus
-  randomized beacon jitter. Stealth is best-effort (spread spectrum + low duty),
-  not true inaudibility, since the PS1240 resonates at 4 kHz. UART: `LINK`,
-  `LINK ID <0-7>`, `LINK BEACON`, `LINK WIFI`. Understanding + FAQ:
-  [`wiki.md`](wiki.md) (English) / [`wiki.cs.md`](wiki.cs.md) (Čeština).
-  Full protocol docs: [`chirp.md`](chirp.md) / [`chirp.cs.md`](chirp.cs.md);
-  see also [`acoustic_link.h`](acoustic_link.h) / [`node_store.h`](node_store.h).
+* **Acoustic node link (v1.4.0+).** Nodes talk over the existing GP6/GP7 PS1240
+  piezo with a **fast FHSS PHY**: 31-chip BPSK preamble at 4 kHz (CDMA) plus
+  **non-coherent 2-FSK** data on an 8-tone hop set (~3–5.4 kHz). One frame is
+  **~70 ms on air** (&lt; 100 ms budget; v1.3 was ~7 s and wire-incompatible).
+  Fixed 31-byte frame + CRC32 (no Hamming); reserved crypto fields for future
+  AEAD. RX uses the 6-mic 48 kHz mono mix. Features: **SS-TWR ranging** (baro
+  \(c\)), **coarse time sync** (`TIME` source `acoustic`), `BEACON` / `DETECT` /
+  `CTRL` (`WIFI_WAKE`). UART: `LINK`, `LINK ID <0-7>`, `LINK BEACON`, `LINK WIFI`.
+  FAQ: [`wiki.md`](wiki.md) / [`wiki.cs.md`](wiki.cs.md). Protocol:
+  [`chirp.md`](chirp.md) / [`chirp.cs.md`](chirp.cs.md).
 
 * **OpenDroneID / EU Direct Remote ID (v1.1.0+).** On CYW43 boards
   (`PICO_BOARD=pico_w`, `pico2_w`, `pimoroni_pico_plus2_w_rp2350`, or other Pico W
@@ -271,12 +265,9 @@ Alongside the USB sound card the firmware runs an autonomous acoustic front-end:
   what to build it from, and a full edge-length trade-off analysis (accuracy, speed,
   compute, memory) are in [`array_cube_design.md`](array_cube_design.md).
 
-* **Synchronisation beacon.** The PS1240 piezo emits a periodic BPSK-modulated
-  m-sequence burst on a ~4 kHz carrier (its resonance), driven differentially via
-  the GP6/GP7 software H-bridge. This pseudo-noise code is what neighbouring nodes
-  will cross-correlate (matched filter) for acoustic ranging / clock sync; the
-  receive/ranging side is a later phase. The beacon count appears in the heartbeat
-  (`bcn=`).
+* **Synchronisation / node beacons.** The PS1240 is driven differentially on
+  GP6/GP7. From v1.4.0 the acoustic link owns short FHSS chirps (~70 ms); a rare
+  idle PN keepalive may still bump `bcn=` in the heartbeat.
 
 ## Downloads
 

--- a/acoustic_link.c
+++ b/acoustic_link.c
@@ -1,6 +1,5 @@
-// acoustic_link.c — DSSS-BPSK node link on the GP6/GP7 4 kHz piezo + mic RX.
-// See acoustic_link.h for the layering overview. No malloc; RX runs in bounded
-// chunks from the main loop; TX hands a chip buffer to the buzzer ISR.
+// acoustic_link.c — fast FHSS-BPSK node link on the GP6/GP7 PS1240 + mic RX.
+// Wire version 2 (firmware 1.4.0): ~70 ms/frame. See acoustic_link.h.
 #include "acoustic_link.h"
 #include "buzzer.h"
 #include "node_store.h"
@@ -15,41 +14,47 @@
 #define HET68_WIFI_WAKE 0
 #endif
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 // ---------------------------------------------------------------------------
-// Node identity + codes
+// Node identity + degree-5 Gold preamble codes (length 31)
 // ---------------------------------------------------------------------------
 static uint8_t g_node_id;
 
 static int8_t g_pre_code[ALINK_MAX_NODES][ALINK_PREAMBLE_LEN];   // +1/-1
-static int8_t g_data_code[ALINK_MAX_NODES][ALINK_DATA_SF];       // +1/-1
 
-// Two maximal-length degree-7 LFSRs (a preferred-pair Gold construction):
-//   seqA: x^7 + x^6 + 1   seqB: x^7 + x^3 + 1
-static void build_mseq(uint8_t taps_hi, uint8_t taps_lo, uint8_t out[ALINK_PREAMBLE_LEN]) {
-    uint8_t lfsr = 0x7Fu;
+// Hop set around PS1240 resonance (~4 kHz). Nearby tones still couple into the
+// element; hopping breaks the long tonal whistle that made v1.3 unbearable.
+static const uint16_t g_hop_hz[ALINK_NHOPS] = {
+    3000u, 3400u, 3800u, 4000u, 4200u, 4600u, 5000u, 5400u
+};
+
+static void build_mseq5(uint8_t tap_a, uint8_t tap_b, uint8_t out[ALINK_PREAMBLE_LEN]) {
+    uint8_t lfsr = 0x1Fu;
     for (uint32_t i = 0; i < ALINK_PREAMBLE_LEN; i++) {
-        uint8_t bit = (uint8_t)(((lfsr >> taps_hi) ^ (lfsr >> taps_lo)) & 1u);
+        uint8_t bit = (uint8_t)(((lfsr >> tap_a) ^ (lfsr >> tap_b)) & 1u);
         out[i] = (uint8_t)(lfsr & 1u);
-        lfsr = (uint8_t)(((lfsr << 1) | bit) & 0x7Fu);
+        lfsr = (uint8_t)(((lfsr << 1) | bit) & 0x1Fu);
     }
 }
 
 static void build_codes(void) {
-    uint8_t a[ALINK_PREAMBLE_LEN], b[ALINK_PREAMBLE_LEN];
-    build_mseq(6u, 5u, a);   // taps at register bits 6,5  -> x^7+x^6+1
-    build_mseq(6u, 2u, b);   // taps at register bits 6,2  -> x^7+x^3+1
+    // Length-31 m-sequence with distinct circular shifts per node (CDMA).
+    uint8_t a[ALINK_PREAMBLE_LEN];
+    build_mseq5(4u, 1u, a);   // x^5 + x^2 + 1
     for (uint32_t n = 0; n < ALINK_MAX_NODES; n++) {
+        uint32_t shift = n * 3u;   // well-separated phases in 31-space
         for (uint32_t k = 0; k < ALINK_PREAMBLE_LEN; k++) {
-            uint8_t g = a[k] ^ b[(k + n) % ALINK_PREAMBLE_LEN];   // Gold family
+            uint8_t g = a[(k + shift) % ALINK_PREAMBLE_LEN];
             g_pre_code[n][k] = g ? -1 : +1;
         }
-        for (uint32_t k = 0; k < ALINK_DATA_SF; k++)
-            g_data_code[n][k] = g_pre_code[n][k];
     }
 }
 
 // ---------------------------------------------------------------------------
-// CRC32 (IEEE 802.3, same poly as the flash stores)
+// CRC32 (IEEE 802.3)
 // ---------------------------------------------------------------------------
 static uint32_t crc32(const uint8_t *d, uint32_t len) {
     uint32_t c = 0xFFFFFFFFu;
@@ -62,47 +67,11 @@ static uint32_t crc32(const uint8_t *d, uint32_t len) {
 }
 
 // ---------------------------------------------------------------------------
-// Hamming(7,4) FEC — single-error-correcting, per nibble
-// ---------------------------------------------------------------------------
-static void hamming_enc(uint8_t nib, uint8_t out[7]) {
-    uint8_t d0 = (nib >> 0) & 1u, d1 = (nib >> 1) & 1u;
-    uint8_t d2 = (nib >> 2) & 1u, d3 = (nib >> 3) & 1u;
-    out[0] = (uint8_t)(d0 ^ d1 ^ d3);   // p1
-    out[1] = (uint8_t)(d0 ^ d2 ^ d3);   // p2
-    out[2] = d0;
-    out[3] = (uint8_t)(d1 ^ d2 ^ d3);   // p3
-    out[4] = d1;
-    out[5] = d2;
-    out[6] = d3;
-}
-
-static uint8_t hamming_dec(const uint8_t in[7]) {
-    uint8_t p1 = in[0], p2 = in[1], d0 = in[2], p3 = in[3];
-    uint8_t d1 = in[4], d2 = in[5], d3 = in[6];
-    uint8_t s1 = (uint8_t)(p1 ^ d0 ^ d1 ^ d3);
-    uint8_t s2 = (uint8_t)(p2 ^ d0 ^ d2 ^ d3);
-    uint8_t s3 = (uint8_t)(p3 ^ d1 ^ d2 ^ d3);
-    uint8_t syn = (uint8_t)(s1 | (s2 << 1) | (s3 << 2));
-    if (syn) {
-        // Syndrome (s1,s2,s3) -> codeword index (see hamming_enc layout):
-        //   001->p1(0) 010->p2(1) 011->d0(2) 100->p3(3)
-        //   101->d1(4) 110->d2(5) 111->d3(6)
-        static const int synmap[8] = { -1, 0, 1, 2, 3, 4, 5, 6 };
-        uint8_t v[7] = { in[0], in[1], in[2], in[3], in[4], in[5], in[6] };
-        int p = synmap[syn & 7u];
-        if (p >= 0) v[p] ^= 1u;
-        d0 = v[2]; d1 = v[4]; d2 = v[5]; d3 = v[6];
-    }
-    return (uint8_t)(d0 | (d1 << 1) | (d2 << 2) | (d3 << 3));
-}
-
-// ---------------------------------------------------------------------------
-// Crypto hook (reserved). Today a no-op pass-through; the frame already
-// carries key_id/nonce/flags so enabling AEAD later needs no wire change.
+// Crypto hook (reserved stub)
 // ---------------------------------------------------------------------------
 static bool crypto_seal(uint8_t *payload, uint8_t len, uint8_t key_id, uint32_t nonce) {
     (void)payload; (void)len; (void)key_id; (void)nonce;
-    return true;   // TODO: AEAD (encrypt-then-MAC), e.g. ChaCha20-Poly1305
+    return true;
 }
 static bool crypto_open(uint8_t *payload, uint8_t len, uint8_t key_id, uint32_t nonce) {
     (void)payload; (void)len; (void)key_id; (void)nonce;
@@ -112,37 +81,37 @@ static bool crypto_open(uint8_t *payload, uint8_t len, uint8_t key_id, uint32_t 
 // ---------------------------------------------------------------------------
 // TX
 // ---------------------------------------------------------------------------
-static uint8_t  s_tx_chips[ALINK_TX_CHIPS];
+static uint8_t  s_tx_phase[ALINK_TX_CHIPS];
+static uint16_t s_tx_freq[ALINK_TX_CHIPS];
 static uint8_t  s_tx_seq;
 static uint32_t s_tx_count;
-static uint8_t  s_pending_seq;        // seq of frame currently being emitted
-static bool     s_pending_note;       // need to record accurate t1 once it starts
+static uint8_t  s_pending_seq;
+static bool     s_pending_note;
 static uint64_t s_last_tx_start_us;
 
-// Build the 434-bit Hamming-coded stream from 31 plaintext bytes, then spread.
 static void build_tx_chips(const uint8_t frame[ALINK_FRAME_BYTES]) {
-    uint8_t bits[ALINK_CODED_BITS];
-    uint32_t bi = 0;
-    for (uint32_t i = 0; i < ALINK_FRAME_BYTES; i++) {
-        uint8_t hi = (uint8_t)(frame[i] >> 4);
-        uint8_t lo = (uint8_t)(frame[i] & 0x0Fu);
-        uint8_t cw[7];
-        hamming_enc(hi, cw);
-        for (int k = 0; k < 7; k++) bits[bi++] = cw[k];
-        hamming_enc(lo, cw);
-        for (int k = 0; k < 7; k++) bits[bi++] = cw[k];
-    }
-
     uint32_t ci = 0;
     const int8_t *pre = g_pre_code[g_node_id % ALINK_MAX_NODES];
-    const int8_t *dc  = g_data_code[g_node_id % ALINK_MAX_NODES];
-    for (uint32_t k = 0; k < ALINK_PREAMBLE_LEN; k++)
-        s_tx_chips[ci++] = (pre[k] < 0) ? 1u : 0u;   // amplitude -> phase bit
-    for (uint32_t b = 0; b < ALINK_CODED_BITS; b++) {
-        int amp_bit = (bits[b] ? -1 : +1);
-        for (uint32_t k = 0; k < ALINK_DATA_SF; k++) {
-            int amp = amp_bit * dc[k];              // (1-2b)*code
-            s_tx_chips[ci++] = (amp < 0) ? 1u : 0u;
+
+    // Preamble: fixed 4 kHz, Gold phase code (CDMA acquisition).
+    for (uint32_t k = 0; k < ALINK_PREAMBLE_LEN; k++) {
+        s_tx_phase[ci] = (pre[k] < 0) ? 1u : 0u;
+        s_tx_freq[ci] = ALINK_PREAMBLE_HZ;
+        ci++;
+    }
+
+    // Data: raw frame bits as non-coherent 2-FSK on the hop set.
+    // PWM retune destroys absolute carrier phase, so BPSK-on-hop is unreliable;
+    // each bit picks one of two hop tones (energy detection on RX).
+    for (uint32_t i = 0; i < ALINK_FRAME_BYTES; i++) {
+        for (int b = 7; b >= 0; b--) {
+            uint8_t bit = (uint8_t)((frame[i] >> b) & 1u);
+            uint32_t di = ci - ALINK_PREAMBLE_LEN;
+            uint32_t base = (di + (uint32_t)g_node_id * 3u) % ALINK_NHOPS;
+            uint32_t hi = (base + (bit ? (ALINK_NHOPS / 2u) : 0u)) % ALINK_NHOPS;
+            s_tx_phase[ci] = 0u;   // fixed drive polarity; info is in frequency
+            s_tx_freq[ci] = g_hop_hz[hi];
+            ci++;
         }
     }
 }
@@ -169,7 +138,6 @@ bool acoustic_link_send(uint8_t type, uint8_t flags,
     frame[10] = len;
     if (payload && len) memcpy(&frame[11], payload, len);
 
-    // Seal payload region in place (stub today).
     if (flags & ALINK_FLAG_ENCRYPTED)
         (void)crypto_seal(&frame[11], ALINK_MAX_PAYLOAD, key_id, nonce);
 
@@ -180,7 +148,7 @@ bool acoustic_link_send(uint8_t type, uint8_t flags,
     frame[30] = (uint8_t)((crc >> 24) & 0xFF);
 
     build_tx_chips(frame);
-    if (!buzzer_tx_chips(s_tx_chips, ALINK_TX_CHIPS)) return false;
+    if (!buzzer_tx_chips_fh(s_tx_phase, s_tx_freq, ALINK_TX_CHIPS)) return false;
 
     s_pending_seq = s_tx_seq;
     s_pending_note = (type == ALINK_FT_BEACON);
@@ -190,10 +158,10 @@ bool acoustic_link_send(uint8_t type, uint8_t flags,
 }
 
 // ---------------------------------------------------------------------------
-// Beacon scheduling (slotted-ALOHA-ish: periodic + random jitter)
+// Beacon scheduling
 // ---------------------------------------------------------------------------
-#define BEACON_BASE_MS   1500u
-#define BEACON_JITTER_MS 500u
+#define BEACON_BASE_MS   2000u
+#define BEACON_JITTER_MS 800u
 static uint64_t s_next_beacon_us;
 static uint32_t s_lcg = 0x1234567u;
 
@@ -206,11 +174,11 @@ static void schedule_tx(void) {
         return;
     }
     if (now < s_next_beacon_us) return;
-    if (buzzer_tx_busy()) return;   // listen/hold: don't stomp our own PHY
+    if (buzzer_tx_busy()) return;
 
     uint8_t p[ALINK_MAX_PAYLOAD];
     memset(p, 0, sizeof(p));
-    uint32_t tx_mono = (uint32_t)now;              // approx send time (low32)
+    uint32_t tx_mono = (uint32_t)now;
     uint32_t epoch = het68_time_synced() ? het68_time_epoch_sec() : 0u;
     p[0] = (uint8_t)(tx_mono & 0xFF);
     p[1] = (uint8_t)((tx_mono >> 8) & 0xFF);
@@ -240,62 +208,57 @@ static void schedule_tx(void) {
 }
 
 // ---------------------------------------------------------------------------
-// RX ring (SPSC: producer = USB frame builder, consumer = poll)
+// RX ring
 // ---------------------------------------------------------------------------
 #define RX_RING 8192u
 static int16_t          s_rx_ring[RX_RING];
-static volatile uint32_t s_rx_head;   // producer
-static volatile uint32_t s_rx_tail;   // consumer
+static volatile uint32_t s_rx_head;
+static volatile uint32_t s_rx_tail;
 
 void acoustic_link_rx_push(int16_t mono) {
     uint32_t h = s_rx_head;
     uint32_t nh = (h + 1u) & (RX_RING - 1u);
-    if (nh == s_rx_tail) return;       // full: drop (bounded, non-blocking)
+    if (nh == s_rx_tail) return;
     s_rx_ring[h] = mono;
     s_rx_head = nh;
 }
 
 // ---------------------------------------------------------------------------
-// RX matched filter / despreader
+// RX: 4 kHz preamble correlator + FHSS data demod
 // ---------------------------------------------------------------------------
-static float s_cos_lut[ALINK_SAMPLES_CYCLE];
-static float s_sin_lut[ALINK_SAMPLES_CYCLE];
-static uint32_t s_smp_phase;
+static float s_cos4[ALINK_SAMPLES_CHIP];
+static float s_sin4[ALINK_SAMPLES_CHIP];
+// Per-hop baseband LUTs over one chip window (12 samples).
+static float s_hop_cos[ALINK_NHOPS][ALINK_SAMPLES_CHIP];
+static float s_hop_sin[ALINK_NHOPS][ALINK_SAMPLES_CHIP];
 
-// Integrate-and-dump chip accumulator.
-static float s_i_acc, s_q_acc;
-static uint32_t s_chip_smp;
+static float s_chip_buf[ALINK_SAMPLES_CHIP];
+static uint32_t s_chip_fill;
 
-// Preamble chip history (circular).
 static float s_hist_i[ALINK_PREAMBLE_LEN];
 static float s_hist_q[ALINK_PREAMBLE_LEN];
 static uint32_t s_hist_head;
 static uint32_t s_hist_fill;
 
-// Receiver state machine.
 enum { RX_SEARCH = 0, RX_DATA };
 static uint8_t  s_rx_state;
-static uint8_t  s_rx_node;       // detected sender code index
-static float    s_rx_cos, s_rx_sin;  // channel phase reference
+static uint8_t  s_rx_node;
+static float    s_rx_cos, s_rx_sin;
 static uint64_t s_rx_toa_us;
 static float    s_rx_q;
 static uint32_t s_bit_idx;
-static uint32_t s_chip_in_bit;
-static float    s_bit_i, s_bit_q;
-static uint8_t  s_coded[ALINK_CODED_BITS];
+static uint8_t  s_raw_bits[ALINK_RAW_BITS];
 
 static uint32_t s_rx_count;
 static uint32_t s_rx_bad_crc;
 static volatile bool s_wifi_wake_pending;
 
-#define DETECT_RHO   0.30f     // normalized correlation threshold
-#define DETECT_EMIN  1.0e6f    // minimum window energy to consider a peak
+#define DETECT_RHO   0.28f
+#define DETECT_EMIN  5.0e5f
 
 static void rx_reset_search(void) {
     s_rx_state = RX_SEARCH;
     s_bit_idx = 0;
-    s_chip_in_bit = 0;
-    s_bit_i = s_bit_q = 0.0f;
 }
 
 static void dispatch_frame(const alink_frame_t *f);
@@ -303,9 +266,10 @@ static void dispatch_frame(const alink_frame_t *f);
 static void finalize_frame(void) {
     uint8_t bytes[ALINK_FRAME_BYTES];
     for (uint32_t i = 0; i < ALINK_FRAME_BYTES; i++) {
-        uint8_t hi = hamming_dec(&s_coded[(i * 2u) * 7u]);
-        uint8_t lo = hamming_dec(&s_coded[(i * 2u + 1u) * 7u]);
-        bytes[i] = (uint8_t)((hi << 4) | (lo & 0x0Fu));
+        uint8_t v = 0;
+        for (int b = 0; b < 8; b++)
+            v = (uint8_t)((v << 1) | (s_raw_bits[i * 8u + (uint32_t)b] & 1u));
+        bytes[i] = v;
     }
     uint32_t crc = crc32(bytes, 27);
     uint32_t rx_crc = (uint32_t)bytes[27] | ((uint32_t)bytes[28] << 8) |
@@ -330,29 +294,44 @@ static void finalize_frame(void) {
     f.corr_q = s_rx_q;
     if (f.flags & ALINK_FLAG_ENCRYPTED)
         (void)crypto_open(f.payload, ALINK_MAX_PAYLOAD, f.key_id, f.nonce);
+    // Prefer header node_id when it matches the CDMA detection.
+    if (f.node_id >= ALINK_MAX_NODES) f.node_id = s_rx_node;
     s_rx_count++;
     dispatch_frame(&f);
     rx_reset_search();
 }
 
-// One completed chip (complex) at local time chip_us.
-static void rx_on_chip(float ci, float cq, uint64_t chip_us) {
+static void mix_chip(const float *buf, const float *c, const float *s,
+                     float *oi, float *oq) {
+    float ri = 0.0f, rq = 0.0f;
+    for (uint32_t n = 0; n < ALINK_SAMPLES_CHIP; n++) {
+        ri += buf[n] * c[n];
+        rq += buf[n] * s[n];
+    }
+    *oi = ri;
+    *oq = rq;
+}
+
+static void rx_on_chip(const float *buf, uint64_t chip_us) {
     if (s_rx_state == RX_DATA) {
-        const int8_t *dc = g_data_code[s_rx_node];
-        s_bit_i += ci * (float)dc[s_chip_in_bit];
-        s_bit_q += cq * (float)dc[s_chip_in_bit];
-        if (++s_chip_in_bit >= ALINK_DATA_SF) {
-            float val = s_bit_i * s_rx_cos + s_bit_q * s_rx_sin;  // derotate
-            s_coded[s_bit_idx] = (val < 0.0f) ? 1u : 0u;
-            s_bit_idx++;
-            s_chip_in_bit = 0;
-            s_bit_i = s_bit_q = 0.0f;
-            if (s_bit_idx >= ALINK_CODED_BITS) finalize_frame();
-        }
+        uint32_t di = s_bit_idx;
+        uint32_t base = (di + (uint32_t)s_rx_node * 3u) % ALINK_NHOPS;
+        uint32_t h0 = base;
+        uint32_t h1 = (base + ALINK_NHOPS / 2u) % ALINK_NHOPS;
+        float i0, q0, i1, q1;
+        mix_chip(buf, s_hop_cos[h0], s_hop_sin[h0], &i0, &q0);
+        mix_chip(buf, s_hop_cos[h1], s_hop_sin[h1], &i1, &q1);
+        float e0 = i0 * i0 + q0 * q0;
+        float e1 = i1 * i1 + q1 * q1;
+        s_raw_bits[s_bit_idx] = (e1 > e0) ? 1u : 0u;
+        s_bit_idx++;
+        if (s_bit_idx >= ALINK_RAW_BITS) finalize_frame();
         return;
     }
 
-    // SEARCH: push chip into history, correlate against candidate codes.
+    // SEARCH on fixed 4 kHz preamble.
+    float ci, cq;
+    mix_chip(buf, s_cos4, s_sin4, &ci, &cq);
     s_hist_i[s_hist_head] = ci;
     s_hist_q[s_hist_head] = cq;
     s_hist_head = (s_hist_head + 1u) % ALINK_PREAMBLE_LEN;
@@ -368,8 +347,6 @@ static void rx_on_chip(float ci, float cq, uint64_t chip_us) {
     for (uint32_t n = 0; n < ALINK_MAX_NODES; n++) {
         const int8_t *code = g_pre_code[n];
         float ri = 0.0f, rq = 0.0f;
-        // oldest chip is at s_hist_head (just overwritten pos is newest-1);
-        // align code[0] with oldest sample.
         uint32_t idx = s_hist_head;
         for (uint32_t k = 0; k < ALINK_PREAMBLE_LEN; k++) {
             float c = (float)code[k];
@@ -378,7 +355,12 @@ static void rx_on_chip(float ci, float cq, uint64_t chip_us) {
             idx = (idx + 1u) % ALINK_PREAMBLE_LEN;
         }
         float mag2 = ri * ri + rq * rq;
-        if (mag2 > best_mag2) { best_mag2 = mag2; best_node = (int)n; best_ci = ri; best_cq = rq; }
+        if (mag2 > best_mag2) {
+            best_mag2 = mag2;
+            best_node = (int)n;
+            best_ci = ri;
+            best_cq = rq;
+        }
     }
 
     float rho = best_mag2 / ((float)ALINK_PREAMBLE_LEN * energy);
@@ -392,9 +374,6 @@ static void rx_on_chip(float ci, float cq, uint64_t chip_us) {
         s_rx_q = rho;
         s_rx_state = RX_DATA;
         s_bit_idx = 0;
-        s_chip_in_bit = 0;
-        s_bit_i = s_bit_q = 0.0f;
-        // Clear history so the next search starts fresh after this frame.
         s_hist_fill = 0;
     }
 }
@@ -402,7 +381,6 @@ static void rx_on_chip(float ci, float cq, uint64_t chip_us) {
 void acoustic_link_poll(void) {
     schedule_tx();
 
-    // Record the accurate preamble start time for our outstanding beacon poll.
     if (s_pending_note) {
         uint64_t st = buzzer_tx_start_us();
         if (st != 0 && st != s_last_tx_start_us) {
@@ -414,27 +392,20 @@ void acoustic_link_poll(void) {
 
     uint32_t head = s_rx_head;
     uint32_t tail = s_rx_tail;
-    uint32_t avail = (head - tail) & (RX_RING - 1u);
-    if (avail == 0u) return;
+    if (head == tail) return;
 
     uint64_t now = time_us_64();
+    uint32_t avail = (head - tail) & (RX_RING - 1u);
     uint32_t remaining = avail;
     while (tail != head) {
         int16_t x = s_rx_ring[tail];
         tail = (tail + 1u) & (RX_RING - 1u);
         remaining--;
-
-        float xf = (float)x;
-        uint32_t p = s_smp_phase;
-        s_i_acc += xf * s_cos_lut[p];
-        s_q_acc += xf * s_sin_lut[p];
-        s_smp_phase = (p + 1u >= ALINK_SAMPLES_CYCLE) ? 0u : (p + 1u);
-
-        if (++s_chip_smp >= ALINK_SAMPLES_CHIP) {
+        s_chip_buf[s_chip_fill++] = (float)x;
+        if (s_chip_fill >= ALINK_SAMPLES_CHIP) {
             uint64_t chip_us = now - (uint64_t)remaining * 1000000ull / ALINK_FS_HZ;
-            rx_on_chip(s_i_acc, s_q_acc, chip_us);
-            s_i_acc = s_q_acc = 0.0f;
-            s_chip_smp = 0;
+            rx_on_chip(s_chip_buf, chip_us);
+            s_chip_fill = 0;
         }
     }
     s_rx_tail = tail;
@@ -451,14 +422,11 @@ static void wifi_wake(uint8_t token) {
     dbg_putu32(token);
     dbg_puts(" — Wi-Fi STA bring-up requested (bulk sync / OTA)\n");
     dbg_line_unlock(lock);
-    // Actual STA connect is deferred: it needs SSID/credential provisioning and
-    // must coexist with the BTstack/RID cyw43_arch instance. The application
-    // layer polls acoustic_link_wifi_wake_pending() to drive the connect + OTA.
 }
 #else
 static void wifi_wake(uint8_t token) {
     (void)token;
-    s_wifi_wake_pending = true;   // recorded even on non-wireless boards
+    s_wifi_wake_pending = true;
     dbg_puts("LINK: WIFI_WAKE received — no Wi-Fi on this board\n");
 }
 #endif
@@ -480,7 +448,6 @@ static void dispatch_frame(const alink_frame_t *f) {
                                  peer_tx, echo_node, echo_seq, t_reply,
                                  peer_synced, f->corr_q, doa_c_sound_m_s());
 
-            // Coarse time adoption from a synced peer when we are unsynced.
             if (peer_synced && epoch > 1700000000u && !het68_time_synced())
                 (void)het68_time_sync_from(epoch, HET68_TIME_SRC_ACOUSTIC, 60u);
             break;
@@ -512,14 +479,23 @@ static void dispatch_frame(const alink_frame_t *f) {
 void acoustic_link_init(uint8_t node_id) {
     g_node_id = node_id;
     build_codes();
-    for (uint32_t i = 0; i < ALINK_SAMPLES_CYCLE; i++) {
-        float a = 2.0f * 3.14159265f * (float)i / (float)ALINK_SAMPLES_CYCLE;
-        s_cos_lut[i] = cosf(a);
-        s_sin_lut[i] = sinf(a);
+
+    for (uint32_t n = 0; n < ALINK_SAMPLES_CHIP; n++) {
+        float a = 2.0f * (float)M_PI * (float)ALINK_PREAMBLE_HZ *
+                  (float)n / (float)ALINK_FS_HZ;
+        s_cos4[n] = cosf(a);
+        s_sin4[n] = sinf(a);
     }
-    s_smp_phase = 0;
-    s_i_acc = s_q_acc = 0.0f;
-    s_chip_smp = 0;
+    for (uint32_t h = 0; h < ALINK_NHOPS; h++) {
+        for (uint32_t n = 0; n < ALINK_SAMPLES_CHIP; n++) {
+            float a = 2.0f * (float)M_PI * (float)g_hop_hz[h] *
+                      (float)n / (float)ALINK_FS_HZ;
+            s_hop_cos[h][n] = cosf(a);
+            s_hop_sin[h][n] = sinf(a);
+        }
+    }
+
+    s_chip_fill = 0;
     s_hist_head = 0;
     s_hist_fill = 0;
     rx_reset_search();
@@ -545,10 +521,18 @@ uint32_t acoustic_link_rx_bad_crc(void) { return s_rx_bad_crc; }
 bool acoustic_link_tx_busy(void) { return buzzer_tx_busy(); }
 bool acoustic_link_wifi_wake_pending(void) { return s_wifi_wake_pending; }
 
+uint32_t acoustic_link_frame_air_us(void) {
+    return (uint32_t)ALINK_TX_CHIPS * (uint32_t)ALINK_CHIP_US;
+}
+
 void acoustic_link_status_uart(void) {
     uint32_t lock = dbg_line_lock();
     dbg_puts("LINK node=");
     dbg_putu32(g_node_id);
+    dbg_puts(" ver=");
+    dbg_putu32(ALINK_VERSION);
+    dbg_puts(" air_ms=");
+    dbg_putu32(acoustic_link_frame_air_us() / 1000u);
     dbg_puts(" tx=");
     dbg_putu32(s_tx_count);
     dbg_puts(" rx=");

--- a/acoustic_link.h
+++ b/acoustic_link.h
@@ -1,60 +1,59 @@
-// acoustic_link.h — node-to-node acoustic link over the GP6/GP7 4 kHz piezo.
+// acoustic_link.h — node-to-node acoustic link over the GP6/GP7 PS1240 piezo.
 //
-// PHY : DSSS-BPSK on the existing PS1240 H-bridge beacon engine (buzzer.c).
-// MAC : per-node CDMA code (Gold family) + slotted-ALOHA jitter, fixed frame.
-// SEC : Hamming(7,4) FEC + CRC32, reserved key_id/nonce/flags for future AEAD.
-// APP : BEACON (ranging + coarse time), DETECT (summary), CTRL (wifi-wake/OTA).
+// PHY (v1.4 / wire version 2):
+//   Fast FHSS on the PS1240. Fixed 250 µs chips, 31-chip m-sequence preamble
+//   (BPSK @ 4 kHz) for CDMA acquisition, then data as non-coherent 2-FSK on an
+//   8-tone hop set around resonance — one frame ~70 ms (< 100 ms) and far less
+//   tonal than the old ~7 s DSSS whistle.
+// MAC : per-node CDMA preamble code + slotted-ALOHA jitter, fixed frame.
+// SEC : CRC32 (Hamming dropped for air-time); reserved key_id/nonce/flags for AEAD.
+// APP : BEACON (ranging + coarse time), DETECT, CTRL (wifi-wake/OTA).
 //
-// RX rides on the 6-mic 48 kHz capture: main.c feeds a mono mix to
-// acoustic_link_rx_push(); acoustic_link_poll() runs a bounded matched filter.
-// No malloc, no blocking in the realtime path (see AGENTS.md).
+// RX rides on the 6-mic 48 kHz capture. No malloc, no blocking in the realtime
+// path (see AGENTS.md).
 #pragma once
 #include <stdint.h>
 #include <stdbool.h>
 
-// --- PHY timing (locked to the buzzer carrier) ------------------------------
-#define ALINK_CARRIER_HZ     4000u
+// --- PHY timing -------------------------------------------------------------
 #define ALINK_FS_HZ          48000u
-#define ALINK_SAMPLES_CYCLE  (ALINK_FS_HZ / ALINK_CARRIER_HZ)          // 12
-#define ALINK_CYCLES_CHIP    8u
-#define ALINK_SAMPLES_CHIP   (ALINK_SAMPLES_CYCLE * ALINK_CYCLES_CHIP) // 96
-#define ALINK_CHIP_HZ        (ALINK_FS_HZ / ALINK_SAMPLES_CHIP)        // 500
+#define ALINK_CHIP_US        250u
+#define ALINK_SAMPLES_CHIP   ((ALINK_FS_HZ * ALINK_CHIP_US) / 1000000u)  // 12
+#define ALINK_PREAMBLE_HZ    4000u    // fixed-frequency acquisition carrier
 
 // --- Spreading / framing ----------------------------------------------------
-#define ALINK_PREAMBLE_LEN   127u   // length-127 m-sequence / Gold code
-#define ALINK_DATA_SF        8u     // chips per coded data bit
-#define ALINK_MAX_NODES      8u     // distinct CDMA codes tracked on RX
+#define ALINK_PREAMBLE_LEN   31u    // degree-5 Gold family
+#define ALINK_DATA_SF        1u     // one chip per data bit (air-time critical)
+#define ALINK_MAX_NODES      8u
+#define ALINK_NHOPS          8u     // FHSS hop-set size (data chips)
 
-#define ALINK_VERSION        1u
+#define ALINK_VERSION        2u     // wire version (1.3.x used version 1 + Hamming)
 #define ALINK_MAX_PAYLOAD    16u
-// Fixed on-air plaintext frame (padded): keeps RX sizing constant.
+// Fixed on-air plaintext frame (padded):
 //   [0]=ver [1]=node_id [2]=type [3]=seq [4]=flags [5]=key_id
 //   [6..9]=nonce [10]=len [11..26]=payload[16] [27..30]=crc32
 #define ALINK_FRAME_BYTES    31u
-// Hamming(7,4): 2 nibbles/byte * 7 bits.
-#define ALINK_CODED_BITS     (ALINK_FRAME_BYTES * 2u * 7u)             // 434
-#define ALINK_TX_CHIPS       (ALINK_PREAMBLE_LEN + ALINK_CODED_BITS * ALINK_DATA_SF) // 3599
+#define ALINK_RAW_BITS       (ALINK_FRAME_BYTES * 8u)                    // 248
+#define ALINK_TX_CHIPS       (ALINK_PREAMBLE_LEN + ALINK_RAW_BITS * ALINK_DATA_SF) // 279
+// Air-time: 279 * 250 µs = 69.75 ms (< 100 ms).
 
 // Frame types.
 enum {
-    ALINK_FT_BEACON = 0,   // ranging + coarse time sync
-    ALINK_FT_DETECT = 1,   // compact detection summary
-    ALINK_FT_CTRL   = 2,   // control-plane (wifi wake, OTA request)
+    ALINK_FT_BEACON = 0,
+    ALINK_FT_DETECT = 1,
+    ALINK_FT_CTRL   = 2,
     ALINK_FT_ACK    = 3,
 };
 
-// CTRL subtypes (payload[0]).
 enum {
     ALINK_CTRL_WIFI_WAKE = 1,
     ALINK_CTRL_OTA_REQ   = 2,
 };
 
-// Header flags.
-#define ALINK_FLAG_ENCRYPTED  0x01u   // payload sealed (reserved; stub today)
+#define ALINK_FLAG_ENCRYPTED  0x01u
 #define ALINK_FLAG_ACK_REQ    0x02u
-#define ALINK_FLAG_SYNCED     0x04u   // sender clock is synced (epoch valid)
+#define ALINK_FLAG_SYNCED     0x04u
 
-// Decoded frame handed to the dispatcher / CLI.
 typedef struct {
     uint8_t  version;
     uint8_t  node_id;
@@ -65,33 +64,27 @@ typedef struct {
     uint32_t nonce;
     uint8_t  len;
     uint8_t  payload[ALINK_MAX_PAYLOAD];
-    uint64_t rx_time_us;   // local monotonic ToA (matched-filter peak)
-    float    corr_q;       // normalized correlation quality 0..1
+    uint64_t rx_time_us;
+    float    corr_q;
 } alink_frame_t;
 
 void acoustic_link_init(uint8_t node_id);
 void acoustic_link_set_node_id(uint8_t id);
 uint8_t acoustic_link_node_id(void);
 
-// Queue one frame for transmission (non-blocking). Payload padded to 16 B.
-// Returns false if the PHY is busy or args invalid.
 bool acoustic_link_send(uint8_t type, uint8_t flags,
                         const uint8_t *payload, uint8_t len);
-
-// Convenience: broadcast a CTRL WIFI_WAKE with a rendezvous token.
 bool acoustic_link_send_wifi_wake(uint8_t channel_token);
 
-// RX sample sink — cheap, called from the USB/I2S frame builder (core0).
 void acoustic_link_rx_push(int16_t mono);
-
-// Main-loop service: drains the RX ring (bounded), runs the matched filter,
-// dispatches frames, and schedules periodic beacons. Call each loop iteration.
 void acoustic_link_poll(void);
 
-// Diagnostics.
 uint32_t acoustic_link_tx_count(void);
 uint32_t acoustic_link_rx_count(void);
 uint32_t acoustic_link_rx_bad_crc(void);
 bool     acoustic_link_tx_busy(void);
 bool     acoustic_link_wifi_wake_pending(void);
 void     acoustic_link_status_uart(void);
+
+// Nominal air-time of one full chirp frame in microseconds.
+uint32_t acoustic_link_frame_air_us(void);

--- a/buzzer.c
+++ b/buzzer.c
@@ -1,80 +1,81 @@
-// buzzer.c — PS1240 piezo synchronisation beacon. See buzzer.h.
+// buzzer.c — PS1240 piezo PHY. See buzzer.h.
 //
 // Drive scheme (software H-bridge):
 //   GP6 = PWM slice channel A, GP7 = same slice channel B.
-//   Carrier = 50%% square at BUZZER_CARRIER_HZ (PS1240 resonance ~4 kHz).
-//   - SILENT  : both channels same polarity  -> pins in phase -> 0 V across
-//               the element -> no sound.
-//   - DRIVE   : channels opposite polarity    -> differential ±VDD -> sound.
-//   BPSK      : flipping which channel is inverted flips the carrier phase by
-//               180°, i.e. encodes one PN chip.
+//   - SILENT  : both channels same polarity  -> 0 V across the element
+//   - DRIVE   : opposite polarity             -> differential ±VDD
+//   BPSK      : flipping which channel is inverted flips carrier phase 180°
 //
-// A single repeating hardware timer at the chip rate advances the PN code and
-// the beacon schedule. The ISR only writes PWM polarity registers (a few
-// cycles) — it never blocks, never touches UART, and never allocates, so it is
-// safe alongside the realtime USB/I2S path on core0.
+// Chip dwell is fixed (BUZZER_CHIP_US) independent of the instantaneous carrier
+// so FHSS can retune the PWM wrap every chip without stretching air-time.
 #include "buzzer.h"
 #include "pico/stdlib.h"
 #include "hardware/pwm.h"
 #include "hardware/clocks.h"
 #include <stddef.h>
 
-#define BUZZER_PIN_A        6u
-#define BUZZER_PIN_B        7u
-#define BUZZER_CARRIER_HZ   4000u     // PS1240 resonance
-#define BUZZER_CYCLES_CHIP  8u        // carrier cycles per PN chip
-#define BUZZER_PN_LEN       127u      // m-sequence length (LFSR x^7 + x^6 + 1)
-#define BUZZER_PERIOD_MS    1000u     // one beacon burst per second
+#define BUZZER_PIN_A         6u
+#define BUZZER_PIN_B         7u
+#define BUZZER_CARRIER_HZ    4000u     // PS1240 resonance (default / preamble)
+#define BUZZER_CHIP_US       250u      // 0.25 ms/chip -> 279 chips ~= 70 ms
+#define BUZZER_PN_LEN        31u       // short idle keepalive (rare)
+#define BUZZER_PERIOD_MS     30000u    // idle PN at most once per 30 s
 
-// Chip period in microseconds: BUZZER_CYCLES_CHIP carrier cycles.
-#define BUZZER_CHIP_US      ((BUZZER_CYCLES_CHIP * 1000000u) / BUZZER_CARRIER_HZ)
-// Idle chips between bursts (period minus burst length).
-#define BUZZER_IDLE_CHIPS   (((BUZZER_PERIOD_MS * 1000u) / BUZZER_CHIP_US) > BUZZER_PN_LEN \
-                             ? ((BUZZER_PERIOD_MS * 1000u) / BUZZER_CHIP_US) - BUZZER_PN_LEN \
-                             : 1u)
+#define BUZZER_IDLE_CHIPS    (((BUZZER_PERIOD_MS * 1000u) / BUZZER_CHIP_US) > BUZZER_PN_LEN \
+                              ? ((BUZZER_PERIOD_MS * 1000u) / BUZZER_CHIP_US) - BUZZER_PN_LEN \
+                              : 1u)
 
-static uint            s_slice;
-static uint8_t         s_pn[BUZZER_PN_LEN];
+static uint              s_slice;
+static uint8_t           s_pn[BUZZER_PN_LEN];
 static repeating_timer_t s_timer;
+static uint32_t          s_cur_hz;
 
-static volatile int32_t  s_chip = -1;          // -1 = idle, else 0..PN_LEN-1
+static volatile int32_t  s_chip = -1;
 static volatile uint32_t s_idle = 0;
 static volatile uint32_t s_beacons = 0;
 
-// --- Chip-stream TX state (acoustic link) -----------------------------------
-static const uint8_t   *volatile s_stream;      // chip buffer (referenced)
+static const uint8_t   *volatile s_stream_phase;
+static const uint16_t  *volatile s_stream_freq;   // NULL => default carrier
 static volatile uint32_t s_stream_len;
 static volatile uint32_t s_stream_idx;
 static volatile bool     s_stream_active;
-static volatile bool     s_stream_pending;      // commit flag; ISR starts next tick
+static volatile bool     s_stream_pending;
 static volatile uint64_t s_stream_start_us;
 
-// Differential drive for one PN chip: chip=1 -> phase 0, chip=0 -> phase 180.
-static inline void buzzer_set_drive(uint8_t chip) {
-    // (a_inv, b_inv): (false,true) and (true,false) are the two opposite
-    // differential phases; both produce sound, 180° apart.
-    pwm_set_output_polarity(s_slice, chip == 0u, chip != 0u);
+static inline void buzzer_set_drive(uint8_t phase_bit) {
+    pwm_set_output_polarity(s_slice, phase_bit == 0u, phase_bit != 0u);
 }
 
-// In-phase on both pins -> no differential voltage -> silent.
 static inline void buzzer_set_silent(void) {
     pwm_set_output_polarity(s_slice, false, false);
 }
 
+static void buzzer_set_freq_hz(uint32_t hz) {
+    if (hz < 1000u) hz = 1000u;
+    if (hz > 12000u) hz = 12000u;
+    if (hz == s_cur_hz) return;
+    uint32_t sys = clock_get_hz(clk_sys);
+    uint32_t wrap = sys / hz;
+    if (wrap < 2u) wrap = 2u;
+    if (wrap > 65536u) wrap = 65536u;
+    pwm_set_wrap(s_slice, (uint16_t)(wrap - 1u));
+    pwm_set_both_levels(s_slice, (uint16_t)(wrap / 2u), (uint16_t)(wrap / 2u));
+    s_cur_hz = hz;
+}
+
 static void buzzer_build_pn(void) {
-    // 7-bit Fibonacci LFSR, taps 7 and 6 -> maximal length 127.
-    uint8_t lfsr = 0x7Fu;
+    // Degree-5 m-sequence (x^5 + x^2 + 1), length 31.
+    uint8_t lfsr = 0x1Fu;
     for (uint32_t i = 0; i < BUZZER_PN_LEN; i++) {
-        uint8_t bit = (uint8_t)(((lfsr >> 6) ^ (lfsr >> 5)) & 1u);
+        uint8_t bit = (uint8_t)(((lfsr >> 4) ^ (lfsr >> 1)) & 1u);
         s_pn[i] = (uint8_t)(lfsr & 1u);
-        lfsr = (uint8_t)(((lfsr << 1) | bit) & 0x7Fu);
+        lfsr = (uint8_t)(((lfsr << 1) | bit) & 0x1Fu);
     }
 }
 
 static bool buzzer_tick(repeating_timer_t *t) {
     (void)t;
 
-    // Acoustic-link chip stream pre-empts the periodic PN beacon.
     if (s_stream_pending && !s_stream_active) {
         s_stream_active = true;
         s_stream_pending = false;
@@ -83,20 +84,25 @@ static bool buzzer_tick(repeating_timer_t *t) {
     if (s_stream_active) {
         uint32_t idx = s_stream_idx;
         if (idx == 0u) s_stream_start_us = time_us_64();
-        buzzer_set_drive(s_stream[idx]);
+        uint32_t hz = BUZZER_CARRIER_HZ;
+        if (s_stream_freq != NULL) hz = s_stream_freq[idx];
+        buzzer_set_freq_hz(hz);
+        buzzer_set_drive(s_stream_phase[idx]);
         idx++;
         s_stream_idx = idx;
         if (idx >= s_stream_len) {
             s_stream_active = false;
             buzzer_set_silent();
-            // Do not immediately fire the beacon on top of the stream tail.
+            buzzer_set_freq_hz(BUZZER_CARRIER_HZ);
             s_chip = -1;
             s_idle = 0;
         }
         return true;
     }
 
+    // Rare idle keepalive (mostly silent — acoustic_link owns real beacons).
     if (s_chip >= 0) {
+        buzzer_set_freq_hz(BUZZER_CARRIER_HZ);
         buzzer_set_drive(s_pn[s_chip]);
         s_chip++;
         if ((uint32_t)s_chip >= BUZZER_PN_LEN) {
@@ -107,29 +113,26 @@ static bool buzzer_tick(repeating_timer_t *t) {
         }
     } else {
         if (++s_idle >= BUZZER_IDLE_CHIPS) {
-            s_chip = 0;   // start a new burst on the next tick
+            s_chip = 0;
         }
     }
-    return true;  // keep repeating
+    return true;
 }
 
 void buzzer_init(void) {
     buzzer_build_pn();
+    s_cur_hz = 0;
 
     gpio_set_function(BUZZER_PIN_A, GPIO_FUNC_PWM);
     gpio_set_function(BUZZER_PIN_B, GPIO_FUNC_PWM);
-    s_slice = pwm_gpio_to_slice_num(BUZZER_PIN_A);   // GP6/GP7 share one slice
+    s_slice = pwm_gpio_to_slice_num(BUZZER_PIN_A);
 
-    uint32_t wrap = clock_get_hz(clk_sys) / BUZZER_CARRIER_HZ;
-    if (wrap == 0u) wrap = 1u;
     pwm_config c = pwm_get_default_config();
-    pwm_config_set_wrap(&c, (uint16_t)(wrap - 1u));
     pwm_init(s_slice, &c, false);
-    pwm_set_both_levels(s_slice, (uint16_t)(wrap / 2u), (uint16_t)(wrap / 2u));
+    buzzer_set_freq_hz(BUZZER_CARRIER_HZ);
     buzzer_set_silent();
     pwm_set_enabled(s_slice, true);
 
-    // Negative period => fixed cadence independent of callback duration.
     add_repeating_timer_us(-(int64_t)BUZZER_CHIP_US, buzzer_tick, NULL, &s_timer);
 }
 
@@ -137,13 +140,18 @@ uint32_t buzzer_beacon_count(void) {
     return s_beacons;
 }
 
-bool buzzer_tx_chips(const uint8_t *chips, uint32_t n_chips) {
-    if (chips == NULL || n_chips == 0u) return false;
+bool buzzer_tx_chips(const uint8_t *phase_bits, uint32_t n_chips) {
+    return buzzer_tx_chips_fh(phase_bits, NULL, n_chips);
+}
+
+bool buzzer_tx_chips_fh(const uint8_t *phase_bits, const uint16_t *freq_hz,
+                        uint32_t n_chips) {
+    if (phase_bits == NULL || n_chips == 0u) return false;
     if (s_stream_active || s_stream_pending) return false;
-    s_stream = chips;
+    s_stream_phase = phase_bits;
+    s_stream_freq = freq_hz;
     s_stream_len = n_chips;
     s_stream_idx = 0;
-    // Commit last: the ISR only starts once s_stream_pending is observed true.
     s_stream_pending = true;
     return true;
 }
@@ -154,4 +162,8 @@ bool buzzer_tx_busy(void) {
 
 uint64_t buzzer_tx_start_us(void) {
     return s_stream_start_us;
+}
+
+uint32_t buzzer_chip_us(void) {
+    return BUZZER_CHIP_US;
 }

--- a/buzzer.h
+++ b/buzzer.h
@@ -1,38 +1,29 @@
-// buzzer.h — PS1240 piezo synchronisation beacon (software H-bridge).
+// buzzer.h — PS1240 piezo PHY (software H-bridge on GP6/GP7).
 //
-// One passive PS1240 element is driven differentially from two GPIOs (GP6/GP7)
-// configured as the A/B outputs of a single PWM slice. Channel B runs with
-// inverted polarity, so the two pins form a software H-bridge: the element sees
-// ±VDD (twice the swing of a single-ended drive, ~+6 dB SPL). The PS1240
-// resonates near 4 kHz, which is the carrier we use.
+// The passive PS1240 resonates near 4 kHz. The acoustic link drives it with
+// short BPSK chips whose carrier may hop among nearby frequencies (FHSS) so a
+// full frame stays under ~100 ms and does not sound like a long steady tone.
 //
-// The beacon periodically emits a BPSK-modulated maximal-length (m-)sequence
-// burst. This pseudo-random code is what neighbouring nodes will later cross-
-// correlate (matched filter) to recover time-of-flight for ranging and clock
-// sync. The RX/ranging side is a later phase; this module only emits.
+// A repeating chip-rate timer advances either:
+//   - an acoustic-link chip stream (phase + optional per-chip frequency), or
+//   - a rare idle PN keepalive (disabled for long periods; the link owns beacons).
 #pragma once
 #include <stdint.h>
 #include <stdbool.h>
 
-// Configure the PWM carrier + the chip-rate timer. Silent until the first
-// scheduled beacon. Call once from core0 after stdio/clocks are up.
 void buzzer_init(void);
-
-// Number of beacon bursts emitted so far (for heartbeat/diagnostics).
 uint32_t buzzer_beacon_count(void);
 
-// --- Chip-stream TX (acoustic link PHY) --------------------------------------
-// Hand the chip-rate ISR an arbitrary BPSK chip sequence (each byte 0/1 selects
-// the carrier phase). The chips play out one per chip tick, pre-empting the
-// periodic PN beacon; the free-running beacon resumes when the stream ends.
-//
-// The buffer is referenced (not copied) and MUST stay valid until
-// buzzer_tx_busy() returns false. Returns false if a stream is already active.
-bool buzzer_tx_chips(const uint8_t *chips, uint32_t n_chips);
+// Queue a BPSK chip stream. Each byte is a phase bit (0/1). If freq_hz is
+// non-NULL it must have n_chips entries (carrier Hz per chip); otherwise every
+// chip uses the default ~4 kHz resonance. The buffers are referenced (not
+// copied) and must stay valid until buzzer_tx_busy() is false.
+bool buzzer_tx_chips(const uint8_t *phase_bits, uint32_t n_chips);
+bool buzzer_tx_chips_fh(const uint8_t *phase_bits, const uint16_t *freq_hz,
+                        uint32_t n_chips);
 
-// True while a queued chip stream is pending or transmitting.
 bool buzzer_tx_busy(void);
-
-// Absolute time (microseconds since boot) at which chip 0 of the current or
-// most recent stream was emitted. 0 until the first stream starts.
 uint64_t buzzer_tx_start_us(void);
+
+// Fixed chip dwell used by the PHY (microseconds). Air-time = n_chips * this.
+uint32_t buzzer_chip_us(void);

--- a/chirp.cs.md
+++ b/chirp.cs.md
@@ -3,19 +3,24 @@
 Jazyk: [English](chirp.md) · **Čeština**
 
 Tento dokument popisuje, jak spolu nody het68 komunikují, synchronizují si hodiny
-a měří vzájemnou vzdálenost přes palubní **4 kHz piezo PS1240** (GP6/GP7) a
-**pole 6 mikrofonů se vzorkováním 48 kHz** — spojení "chirp" zavedené ve firmwaru
-**v1.3.0** ([`acoustic_link.c`](acoustic_link.c), [`node_store.c`](node_store.c)).
+a měří vzájemnou vzdálenost přes palubní **piezo PS1240** (GP6/GP7) a
+**pole 6 mikrofonů se vzorkováním 48 kHz** — spojení "chirp".
 
-Kratší přehled formou FAQ (UART logování, variabilita rámce, zasazení do
-zbytku firmware): [`wiki.cs.md`](wiki.cs.md) / [`wiki.md`](wiki.md).
+**Firmware v1.4.0** předělal PHY tak, aby **jeden rámec trval ~70 ms na vzduchu**
+(rozpočet: **&lt; 100 ms**), s frekvenčním hoppingem kolem rezonance PS1240 místo
+v1.3 burstu DSSS ~7 s (příliš pomalé a pro ucho nepříjemné).
 
-- Cíle návrhu: odolnost vůči kolizím při provozu více nodů, vzájemná
-  synchronizace času, vzájemné měření vzdálenosti, dobrý dosah a co nejmenší
-  postřehnutelnost pro lidské ucho.
+Zdroje: [`acoustic_link.c`](acoustic_link.c), [`node_store.c`](node_store.c),
+[`buzzer.c`](buzzer.c). FAQ přehled: [`wiki.cs.md`](wiki.cs.md) /
+[`wiki.md`](wiki.md).
+
+- Cíle: multi-node provoz, vzájemná sync času, ranging, použitelný air-time,
+  menší tónová otravnost na stejném piezohardware.
 - Omezení (viz [`AGENTS.md`](AGENTS.md)): žádné `malloc`/`free` v realtime audio
-  cestě, žádné blokování v IRQ/DMA/USB callbacích, pouze ohraničené statické
-  buffery.
+  cestě, žádné blokování v IRQ/DMA/USB callbackách, ohraničené statické buffery.
+
+> **Nekompatibilita na drátě:** v1.4 používá `ALINK_VERSION = 2`. **Není**
+> interoperabilní s v1.3.x (`version = 1`, Hamming + pomalé DSSS).
 
 ---
 
@@ -23,291 +28,180 @@ zbytku firmware): [`wiki.cs.md`](wiki.cs.md) / [`wiki.md`](wiki.md).
 
 ```mermaid
 flowchart LR
-  app["APP: BEACON / DETECT / CTRL"] --> sec["SEC: CRC32 + Hamming(7,4) + rezervované AEAD"]
-  sec --> mac["MAC: id nodu, CDMA (Gold), slotted-ALOHA jitter"]
-  mac --> phy["PHY: DSSS-BPSK, nosná 4 kHz"]
-  phy --> tx["piezo GP6/GP7 (H-můstek)"]
-  tx --> air((vzduch 4 kHz))
-  air --> rx["pole 6 mikrofonů @ 48 kHz -> mono mix"]
-  rx --> mf["přizpůsobený filtr (I/Q, korelace, despreading)"]
+  app["APP: BEACON / DETECT / CTRL"] --> sec["SEC: CRC32 + rezervované AEAD"]
+  sec --> mac["MAC: node id, CDMA preambule, ALOHA jitter"]
+  mac --> phy["PHY: 4 kHz BPSK preambule + 2-FSK FHSS data"]
+  phy --> tx["piezo GP6/GP7 H-můstek"]
+  tx --> air((vzduch ~3–5,4 kHz))
+  air --> rx["6 miků @ 48 kHz -> mono mix"]
+  rx --> mf["korelace preambule / detekce energie hopů"]
   mf --> mac
 ```
 
-- **Vysílání (TX)**: PS1240 je buzeno diferenciálně z GP6/GP7 jako softwarový
-  H-můstek (viz [`buzzer.c`](buzzer.c)). Prohození toho, který kanál je invertovaný,
-  otočí fázi nosné o 180 st., což je jeden BPSK čip. ISR na čipové frekvenci
-  přehrává libovolný buffer čipů (`buzzer_tx_chips`) a v klidu se vrací k
-  periodickému PN majáku.
-- **Příjem (RX)**: [`main.c`](main.c) smíchá vzorky šesti mikrofonů do mono streamu
-  uvnitř `build_usb_frame_from_i2s()` a volá `acoustic_link_rx_push()`. Náročný
-  přizpůsobený filtr běží později, po ohraničených dávkách, z
-  `acoustic_link_poll()` v hlavní smyčce.
+- **TX**: PS1240 diferenciálně z GP6/GP7 (`buzzer.c`). Dwell čipu je pevných
+  **250 µs**; PWM nosná se může přeladit každý čip (`buzzer_tx_chips_fh`).
+- **RX**: [`main.c`](main.c) míchá šest miků do `acoustic_link_rx_push()`;
+  `acoustic_link_poll()` běží matched filter ohraničeně v main loopu.
 
 ---
 
-## 2. Fyzická vrstva (PHY)
-
-Rozprostřené spektrum s přímou sekvencí (DSSS) s modulací BPSK na nosné 4 kHz.
+## 2. Fyzická vrstva (PHY) — v1.4
 
 | Parametr | Symbol | Hodnota |
 |---|---|---|
-| Nosná | `ALINK_CARRIER_HZ` | 4000 Hz |
 | Vzorkovací frekvence | `ALINK_FS_HZ` | 48000 Hz |
-| Vzorků na periodu nosné | `ALINK_SAMPLES_CYCLE` | 12 |
-| Period nosné na čip | `ALINK_CYCLES_CHIP` | 8 |
-| Vzorků na čip | `ALINK_SAMPLES_CHIP` | 96 |
-| Čipová rychlost | `ALINK_CHIP_HZ` | 500 čip/s (2 ms/čip) |
-| Délka preambule | `ALINK_PREAMBLE_LEN` | 127 čipů |
-| Činitel rozprostření dat | `ALINK_DATA_SF` | 8 čipů/bit |
-| Počet různých kódů nodů | `ALINK_MAX_NODES` | 8 |
+| Dwell čipu | `ALINK_CHIP_US` | **250 µs** |
+| Vzorků na čip | `ALINK_SAMPLES_CHIP` | 12 |
+| Nosná preambule | `ALINK_PREAMBLE_HZ` | 4000 Hz (rezonance PS1240) |
+| Délka preambule | `ALINK_PREAMBLE_LEN` | **31** čipů (CDMA) |
+| Datová modulace | — | **nekoherentní 2-FSK** na hop množině |
+| Počet hopů | `ALINK_NHOPS` | 8 |
+| Frekvence hopů | `g_hop_hz[]` | 3000, 3400, 3800, 4000, 4200, 4600, 5000, 5400 Hz |
+| Data SF | `ALINK_DATA_SF` | 1 čip / bit |
+| Nody | `ALINK_MAX_NODES` | 8 |
+| Čipů na rámec | `ALINK_TX_CHIPS` | **279** (= 31 + 248) |
+| **Air-time** | — | **279 × 250 µs = 69,75 ms** |
 
-Každý vyslaný čip je fáze (0 nebo 180 st.). BPSK amplituda `a in {+1,-1}` se mapuje
-na fázový bit `p = (a < 0)`. Despreader obnoví datový bit `b`, protože
+### Proč FHSS + 2-FSK (ne BPSK na hopu)
 
-```
-1 - 2*(b XOR c) = (1 - 2*b) * (1 - 2*c)
-```
+Přeladění PWM wrapu každý čip **resetuje fázi nosné**, takže koherentní BPSK na
+hopujících tónech je nespolehlivé. Datové bity proto volí jeden ze dvou hop tónů
+(offset `NHOPS/2`); přijímač porovnává nekoherentní energii.
+**Preambule zůstává BPSK na pevných 4 kHz** kvůli CDMA akvizici a ToA.
 
-takže vynásobením přijatého čipu lokálním kódovým čipem `(1 - 2*c)` a součtem přes
-činitel rozprostření vznikne `(1 - 2*b) * SF * kanál`.
+### Kódy preambule (CDMA)
 
-### Kódy (CDMA)
+M-sekvence délky 31 (`x^5 + x^2 + 1`) s různými kruhovými posuny podle
+`node_id` (krok 3). Akvizice koreluje I/Q na 4 kHz proti všem 8 kódům.
 
-Kódy jednotlivých nodů tvoří **rodina Goldových kódů** ze dvou maximálních LFSR
-7. řádu (konstrukce z preferovaného páru):
+### Idle keepalive piezа
 
-- sekvence A: `x^7 + x^6 + 1`
-- sekvence B: `x^7 + x^3 + 1`
-- kód nodu: `code_n[k] = A[k] XOR B[(k + n) mod 127]`, mapováno na +/-1.
-
-**Preambule** je celý 127-čipový kód odesílatele (slouží k akvizici, identitě
-odesílatele a k času příchodu). **Rozprostírací kód dat** je prvních `SF` čipů
-téhož kódu. Různé nody se tak oddělí na korelátoru (kódový multiplex, CDMA), což
-umožňuje přežít současné vysílání více nodů.
-
-> Poznámka: optimalita zvoleného preferovaného páru těchto dvou polynomů není
-> laboratorně ověřena; oddělení nodů se opírá i o MAC vrstvu (níže).
+Volně běžící PN burst buzzeru je vzácný (~30 s) a krátký (31 × 250 µs). Skutečný
+provoz mezi nody řídí beacon schedule acoustic linku.
 
 ---
 
 ## 3. Formát rámce
 
-Pevný 31bajtový rámec (nešifrovaná data) drží konstantní velikost pro RX.
+Stále pevných **31 bajtů** plaintextu (API/layout stejný); FEC expanze pryč.
 
-| Offset | Pole | Bajty |
+| Offset | Pole | Bajtů |
 |---|---|---|
-| 0 | verze (`ALINK_VERSION` = 1) | 1 |
+| 0 | verze (`ALINK_VERSION` = **2**) | 1 |
 | 1 | node_id (odesílatel) | 1 |
-| 2 | typ (BEACON/DETECT/CTRL/ACK) | 1 |
+| 2 | type (BEACON/DETECT/CTRL/ACK) | 1 |
 | 3 | seq | 1 |
-| 4 | flags (encrypted / ack-req / synced) | 1 |
-| 5 | key_id (krypto, rezervováno) | 1 |
-| 6..9 | nonce (krypto, rezervováno, LE32) | 4 |
-| 10 | len (délka payloadu 0..16) | 1 |
+| 4 | flags | 1 |
+| 5 | key_id (crypto, rezervováno) | 1 |
+| 6..9 | nonce (LE32, rezervováno) | 4 |
+| 10 | len (0..16) | 1 |
 | 11..26 | payload (doplněno na 16) | 16 |
-| 27..30 | CRC32 přes bajty 0..26 (LE) | 4 |
+| 27..30 | CRC32 LE přes 0..26 | 4 |
 
-- **FEC**: každý bajt se rozdělí na dva nibbly, každý zakódovaný pomocí
-  **Hamming(7,4)** (oprava jedné chyby). 31 bajtů -> 62 nibblů -> 434 kódovaných
-  bitů (`ALINK_CODED_BITS`).
-- **Integrita**: CRC32 (polynom IEEE 802.3 `0xEDB88320`, stejný jako u flash
-  úložišť).
-- **Připraveno na šifrování**: příznak `encrypted` plus `key_id`/`nonce` jsou
-  napojené na háčky `crypto_seal()` / `crypto_open()`. Dnes jde o identitu (no-op);
-  cílem je AEAD (encrypt-then-MAC, např. ChaCha20-Poly1305). Protože pole už jsou
-  na drátě, pozdější zapnutí šifrování nevyžaduje změnu rámce.
+- Na vzduchu: **248 raw bitů** (bez Hammingu) po 31čipové preambuli.
+- Crypto pole zůstávají napojená na stub `crypto_seal` / `crypto_open`.
 
-Proud kódovaných bitů se rozprostře na čipy takto: 127 čipů preambule následovaných
-`434 * 8 = 3472` datovými čipy, tj. celkem `ALINK_TX_CHIPS = 3599` čipů.
+### Payload BEACON (stejná sémantika)
+
+| Off | Obsah |
+|---|---|
+| 0..3 | `tx_mono` LE32 |
+| 4..7 | Unix epocha LE32 (0 pokud nesync) |
+| 8 | `echo_node` (nebo `0xFF`) |
+| 9..12 | `t_reply` LE32 |
+| 13 | `echo_seq` |
+| 14 | synced bajt |
+| 15 | pad |
 
 ---
 
-## 4. Vícenásobný přístup a odolnost vůči kolizím
+## 4. Vícenásobný přístup
 
-1. **CDMA** — různé nody používají různé Goldovy kódy; korelátor obnoví nejsilnější
-   zarovnaný kód i při překryvu vysílání.
-2. **Slotted-ALOHA jitter** — majáky se plánují každých `BEACON_BASE_MS` (1500 ms)
-   plus náhodný `BEACON_JITTER_MS` (0..500 ms), takže periodičtí odesílatelé
-   nezůstanou v zákrytu.
-3. **Poslech před vysíláním** — `schedule_tx()` odmítne začít nový rámec, když je
-   lokální PHY zaneprázdněné (`buzzer_tx_busy()`), takže node nepřepíše vlastní
-   vysílání.
-
-Když je node sám, stále vysílá původní periodický PN maják, takže v1.3.0 je v
-provozu jediného nodu beze změny chování.
+1. **CDMA preambule** — různé posuny oddělují překryté akvizice.
+2. **Per-node hop base** — páry tónů offsetované `node_id * 3`.
+3. **Slotted-ALOHA jitter** — majáky každých ~2000 ms + 0..800 ms náhodně.
+4. **Listen-before-talk** — žádné TX při `buzzer_tx_busy()`.
 
 ---
 
 ## 5. Přijímací řetězec
 
-Běží v `acoustic_link_poll()` a vyprazdňuje SPSC ring plněný přes
-`acoustic_link_rx_push()`.
-
-1. **Směšování dolů** — každý mono vzorek se násobí 12prvkovým cos/sin NCO na
-   4 kHz, čímž vznikne základní pásmo I/Q. Protože 48000/4000 = 12 je celé číslo a
-   96 % 12 = 0, každý čip začíná na stejné fázi NCO.
-2. **Integrate-and-dump** — I/Q se akumuluje přes 96 vzorků do jedné komplexní
-   hodnoty čipu.
-3. **Akvizice** — čip se vloží do 127prvkové kruhové historie a koreluje se
-   (komplexně, nekoherentně) proti všem `ALINK_MAX_NODES` kandidátním kódům
-   preambule. Normalizovaný vrchol je
-
-   ```
-   rho = |corr|^2 / (127 * energie_okna)   v [0, 1]
-   ```
-
-   Rámec je detekován, když `rho > DETECT_RHO` (0,30) a energie okna přesáhne
-   `DETECT_EMIN`. Vítězný index kódu je odesílatel; fáze korelace dává referenci
-   kanálu `(cos phi, sin phi)`; čas čipu je čas příchodu (ToA).
-4. **Despreading** — pro každý z 434 datových bitů se sečte `SF` čipů vynásobených
-   datovým kódem odesílatele, provede se derotace o `phi` a reálná část se rozhodne
-   na bit.
-5. **Dekódování** — Hamming dekóduje 434 bitů -> 31 bajtů, ověří CRC32 a verzi a
-   pak předá k obsluze. Špatné CRC zvýší `rx_bad_crc` a přijímač se vrátí do
-   hledání.
+1. Okna po 12 vzorcích z mono ring bufferu.
+2. **SEARCH** — mix na 4 kHz, korelace historie 31 proti všem kódům;
+   přijetí při `rho > 0.28` + energetický práh.
+3. **DATA** — pro každý bit porovnej energii dvou kandidátních hop tónů.
+4. 248 bitů → 31 bajtů, CRC32 a `version == 2`, dispatch.
 
 ---
 
-## 6. Obousměrné měření vzdálenosti (vzájemná vzdálenost)
+## 6. Two-way ranging (SS-TWR)
 
-Majáky slouží zároveň jako měřicí pakety. het68 používá **jednostranné obousměrné
-měření (SS-TWR)** s broadcast majáky ([`node_store.c`](node_store.c)):
+Algoritmus beze změny ([`node_store.c`](node_store.c)):
+\(\mathrm{ToF}=(T_\mathrm{round}-t_\mathrm{reply})/2\),
+vzdálenost \(=\mathrm{ToF}\cdot c\) s \(c\) z `doa_c_sound_m_s()`.
 
-```mermaid
-sequenceDiagram
-  participant A
-  participant B
-  A->>B: maják seqA @ t1 (hodiny A)
-  Note over B: příjem ToA t2 (hodiny B)
-  B->>A: maják @ t3 (hodiny B), echo {A, seqA, t_reply = t3 - t2}
-  Note over A: příjem ToA t4 (hodiny A)
-  Note over A: Tround = t4 - t1
-  Note over A: ToF = (Tround - t_reply) / 2
-  Note over A: vzdálenost = ToF * c
-```
-
-- `A` si pamatuje čas vyslání `t1` každého ze svých nedávných majáků
-  (`node_store_note_tx`, 8prvkový ring podle seq). Přesné `t1` je čas vyslání
-  preambule z `buzzer_tx_start_us()`.
-- `B` ve svém dalším majáku echem odkáže naposledy slyšený peer: `echo_node`,
-  `echo_seq` a dobu obrátky `t_reply = teď - poslední_rx` (`node_store_pending_echo`).
-- Když `A` uslyší maják, jehož `echo_node == A` a `echo_seq` odpovídá čekajícímu
-  dotazu, spočítá `ToF` a poté `vzdálenost = ToF * c`.
-- **c** je aktuální rychlost zvuku z modelu DPS310 (`doa_c_sound_m_s()`), takže
-  měření sleduje teplotu/tlak/vlhkost.
-- Kontrola smysluplnosti: `0 <= ToF < 600 ms` (~200 m); jinak se vzorek zahodí.
-
-Odvozuje se i hrubý relativní posun hodin:
-`offset(A-B) = t4 - t3 - ToF`, kde `t3` je časové razítko vyslání peeru přenášené v
-payloadu.
+Rozlišení čipu je teď **250 µs ≈ 8,6 cm** při \(c \approx 343\,\mathrm{m/s}\)
+(dříve ~0,69 m při 2 ms).
 
 ---
 
 ## 7. Synchronizace času
 
-Dvě úrovně:
-
-- **Hrubá (epocha).** Synchronizovaný node inzeruje `flags.SYNCED` a vkládá svou
-  unixovou epochu do payloadu majáku. **Nesynchronizovaný** node ji přijme přes
-  `het68_time_sync_from(epoch, HET68_TIME_SRC_ACOUSTIC, quality=60)`. `TIME` /
-  `TIME INFO` pak hlásí zdroj `acoustic`, vedle stávajících `uart` a `rid`
-  ([`het68_time.h`](het68_time.h)). Časová razítka DET logu tak fungují i na nodech,
-  které nikdy nedostaly čas přes UART ani OpenDroneID.
-- **Jemná (offset).** Výměna SS-TWR poskytuje per-peer `clock_offset_us` (viz
-  kapitola 6), který kvantifikuje zbytkový posun mezi sousedy a lze jím později
-  řídit lokální fázově dorovnávaný odhad.
-
-Kvalita akustické epochy (60) je záměrně nižší než UART/RID, aby přímý zdroj času
-vždy vyhrál.
+- Hrubá: peer se `SYNCED` + epochou → převzetí přes `HET68_TIME_SRC_ACOUSTIC` (quality 60).
+- Jemná: per-peer `clock_offset_us` z SS-TWR (v `LINK`).
 
 ---
 
-## 8. Probuzení Wi-Fi / OTA (řídicí rovina -> datová rovina)
+## 8. Wi-Fi wake / OTA
 
-Akustické spojení je nízkorychlostní **stále zapnutá řídicí rovina**. Pro objemná
-data nebo upgrade firmwaru může předat řízení Wi-Fi:
-
-- Rámec `CTRL` s podtypem `WIFI_WAKE` nese rendezvous token.
-- Po přijetí desky s CYW43 (`pico_w`, `pico2_w`, Pico Plus 2 W) nastaví požadavek
-  na spuštění Wi-Fi (`HET68_WIFI_WAKE=1`); aplikační vrstva dotazuje
-  `acoustic_link_wifi_wake_pending()` a řídí připojení STA + objemnou synchronizaci
-  / OTA. Na bezdrátově nevybavené `pico2` se obsluha přeloží jako stub, který jen
-  loguje.
-
-> Skutečné připojení STA + přenos OTA je záměrně odloženo: vyžaduje zajištění
-> SSID/přihlašovacích údajů a musí koexistovat s instancí `cyw43_arch` pro
-> BTstack/RID. Formát na drátě a spouštěč jsou připraveny už teď.
+`CTRL WIFI_WAKE` stále nastaví `acoustic_link_wifi_wake_pending()`; STA/OTA cesta
+je odložená.
 
 ---
 
-## 9. Přehled CLI
-
-Přes ladicí UART (viz [`cli.c`](cli.c)):
+## 9. CLI
 
 | Příkaz | Akce |
 |---|---|
-| `LINK` | stav spojení + tabulka peerů/vzdáleností |
-| `LINK ID <0-7>` | nastav akustické id / CDMA kód tohoto nodu |
-| `LINK BEACON` | vyšli teď jeden maják |
-| `LINK WIFI` | rozešli řídicí rámec `WIFI_WAKE` |
+| `LINK` | status (`ver`, `air_ms`, počítadla) + tabulka peerů |
+| `LINK ID <0-7>` | nastav acoustic id / CDMA posun |
+| `LINK BEACON` | pošli jeden maják |
+| `LINK WIFI` | broadcast `WIFI_WAKE` |
 
-`STATUS` a boot dump obsahují blok `LINK`:
-`node`, `tx`, `rx`, `bad_crc`, `peers`, `wifi_wake`, následovaný tabulkou peerů
-(`id`, `rx`, `q`, `dist_m`, `offset_us`, `synced`).
-
-Pevné id nodu lze nastavit i při buildu: `HET68_NODE_ID=3 ./build.sh`.
+Build-time id: `HET68_NODE_ID=3 ./build.sh`.
 
 ---
 
-## 10. Rozpočet času na vzduchu a datové rychlosti
+## 10. Air-time a slyšitelnost
 
-- Čip = 2 ms. Preambule = 127 čipů = 254 ms. Data = 3472 čipů = 6,944 s.
-  **Jeden rámec ~ 7,2 s** na vzduchu.
-- Čistá informace: 31 bajtů/rámec za ~7,2 s ~= 34 info bit/s (z toho payload 16
-  bajtů).
-- Kadence majáku je tedy fakticky `max(BEACON_BASE_MS, doba rámce na vzduchu)`
-  plus jitter.
+| | v1.3.x | **v1.4.0** |
+|---|---|---|
+| Čipů / rámec | 3599 | **279** |
+| Dwell čipu | 2 ms | **0,25 ms** |
+| Air-time | ~7,2 s | **~70 ms** |
+| Modulace | DSSS-BPSK @ 4 kHz | BPSK preambule + **2-FSK FHSS** |
+| FEC | Hamming(7,4) | jen CRC32 |
 
-Jde záměrně o pomalou, robustní řídicí/měřicí rovinu. Pro výměnu robustnosti za
-rychlost lze snížit `ALINK_DATA_SF`, zkrátit rámec nebo zvýšit čipovou rychlost
-(`ALINK_CYCLES_CHIP`). Velké payloady a OTA patří na Wi-Fi rovinu.
-
----
-
-## 11. Postřehnutelnost
-
-Spojení zůstává na rezonanci ~4 kHz pieza PS1240 (zvoleno kvůli dosahu), což je v
-nejcitlivějším pásmu lidského sluchu, takže **není skutečně neslyšitelné**.
-Postřehnutelnost se minimalizuje rozprostřeným spektrem (energie rozprostřená
-tence, RX funguje i pod 0 dB SNR díky zisku zpracování), nízkým činitelem využití
-a náhodným časováním, takže dávky zní spíš jako slabé cvaknutí/šum než jako tón.
+Duty cyklus při periodě majáku 2 s ≈ **3,5 %** na vzduchu. Hopping rozprostře
+energii do ~3–5,4 kHz — spíš krátké tiky/chirpy než dlouhý pískot. Pořád slyšitelné;
+netvrdíme ticho.
 
 ---
 
-## 12. Omezení a budoucí práce
+## 11. Omezení a budoucí práce
 
-- **Neověřeno na hardwaru**: prahy akvizice, přesnost ToA a volba preferovaného
-  páru Goldových kódů jsou nejlepší odhad a vyžadují laboratorní doladění.
-- **ToA je dnes v rozlišení čipu** (2 ms ~ 0,69 m). Subčipová interpolace vrcholu
-  korelace by měření zpřesnila.
-- **SS-TWR** předpokládá reciprocitu; **oboustranné TWR** by vyrušilo posun hodin.
-- **Krypto** je no-op stub; napojení skutečného AEAD do `crypto_seal`/`crypto_open`
-  zapne příznak `encrypted` beze změny formátu.
-- **Wi-Fi** probuzení jen nastaví příznak; cesta připojení STA + OTA je budoucí
-  práce.
+- Ne plně ověřeno na hardwaru (práh, dosah, pokles SPL mimo rezonanci).
+- Bez Hammingu — spoléháme na CRC + časté krátké majáky.
+- Extrémní hopy mají slabší SPL.
+- Sub-chip interpolace ToA by ještě zpřesnila ranging.
+- Crypto / Wi-Fi OTA stále stuby.
 
 ---
 
-## 13. Mapa zdrojů
+## 12. Mapa zdrojů
 
-- [`acoustic_link.h`](acoustic_link.h) / [`acoustic_link.c`](acoustic_link.c) —
-  PHY, rámcování, FEC/CRC, krypto háčky, plánovač TX, přizpůsobený filtr RX,
-  obsluha.
-- [`node_store.h`](node_store.h) / [`node_store.c`](node_store.c) — tabulka peerů,
-  SS-TWR měření, posun hodin.
-- [`buzzer.h`](buzzer.h) / [`buzzer.c`](buzzer.c) — PHY pieza + vysílání proudu
-  čipů.
-- [`het68_time.h`](het68_time.h) / [`het68_time.c`](het68_time.c) — hodiny se
-  zdrojem `acoustic`.
-- [`main.c`](main.c) — odbočka mono RX + `acoustic_link_poll()` v hlavní smyčce.
-- [`cli.c`](cli.c) — příkazy `LINK` + integrace do `STATUS`.
+- [`acoustic_link.h`](acoustic_link.h) / [`acoustic_link.c`](acoustic_link.c)
+- [`node_store.h`](node_store.h) / [`node_store.c`](node_store.c)
+- [`buzzer.h`](buzzer.h) / [`buzzer.c`](buzzer.c) — FHSS chip stream
+- [`het68_time.*`](het68_time.h) — zdroj času `acoustic`
+- [`main.c`](main.c) / [`cli.c`](cli.c)

--- a/chirp.md
+++ b/chirp.md
@@ -3,18 +3,25 @@
 Language: **English** · [Čeština](chirp.cs.md)
 
 This document describes how het68 nodes talk to each other, synchronize their
-clocks, and measure mutual distance over the on-board **4 kHz PS1240 piezo**
-(GP6/GP7) plus the **6-microphone 48 kHz array** — the "chirp" link introduced in
-firmware **v1.3.0** ([`acoustic_link.c`](acoustic_link.c), [`node_store.c`](node_store.c)).
+clocks, and measure mutual distance over the on-board **PS1240 piezo**
+(GP6/GP7) plus the **6-microphone 48 kHz array** — the "chirp" link.
 
-For a shorter FAQ-oriented overview (UART logging, frame variability, how the
-link fits the rest of the firmware), see [`wiki.md`](wiki.md) /
+**Firmware v1.4.0** redesigned the PHY so **one frame is ~70 ms on air**
+(budget: **&lt; 100 ms**), using frequency hopping around the PS1240 resonance
+instead of the v1.3 ~7 s single-tone DSSS burst (which was too slow and harsh
+on the ear).
+
+Sources: [`acoustic_link.c`](acoustic_link.c), [`node_store.c`](node_store.c),
+[`buzzer.c`](buzzer.c). FAQ-style overview: [`wiki.md`](wiki.md) /
 [`wiki.cs.md`](wiki.cs.md).
 
-- Design goals: collision-resistant multi-node operation, mutual time sync,
-  mutual ranging, good range, and minimal audibility.
+- Design goals: multi-node operation, mutual time sync, mutual ranging, usable
+  air-time, reduced tonal annoyance on the same piezo hardware.
 - Constraints (see [`AGENTS.md`](AGENTS.md)): no `malloc`/`free` in the realtime
   audio path, no blocking in IRQs/DMA/USB callbacks, bounded static buffers.
+
+> **Wire break:** v1.4 uses `ALINK_VERSION = 2`. It is **not** interoperable with
+> v1.3.x (`version = 1`, Hamming + slow DSSS).
 
 ---
 
@@ -22,287 +29,185 @@ link fits the rest of the firmware), see [`wiki.md`](wiki.md) /
 
 ```mermaid
 flowchart LR
-  app["APP: BEACON / DETECT / CTRL"] --> sec["SEC: CRC32 + Hamming(7,4) + reserved AEAD"]
-  sec --> mac["MAC: node id, CDMA (Gold), slotted-ALOHA jitter"]
-  mac --> phy["PHY: DSSS-BPSK, 4 kHz carrier"]
-  phy --> tx["piezo GP6/GP7 (H-bridge)"]
-  tx --> air((air 4 kHz))
-  air --> rx["6-mic array @ 48 kHz -> mono mix"]
-  rx --> mf["matched filter (I/Q, correlate, despread)"]
+  app["APP: BEACON / DETECT / CTRL"] --> sec["SEC: CRC32 + reserved AEAD"]
+  sec --> mac["MAC: node id, CDMA preamble, ALOHA jitter"]
+  mac --> phy["PHY: 4 kHz BPSK preamble + 2-FSK FHSS data"]
+  phy --> tx["piezo GP6/GP7 H-bridge"]
+  tx --> air((air ~3–5.4 kHz))
+  air --> rx["6-mic @ 48 kHz -> mono mix"]
+  rx --> mf["correlate preamble / energy-detect hops"]
   mf --> mac
 ```
 
-- **TX**: the PS1240 is driven differentially from GP6/GP7 as a software H-bridge
-  (see [`buzzer.c`](buzzer.c)). Flipping which channel is inverted flips the
-  carrier phase by 180 deg, i.e. one BPSK chip. The chip-rate ISR streams an
-  arbitrary chip buffer (`buzzer_tx_chips`) and falls back to the periodic PN
-  beacon when idle.
-- **RX**: [`main.c`](main.c) mixes the six microphone samples into a mono stream
-  inside `build_usb_frame_from_i2s()` and calls `acoustic_link_rx_push()`. The
-  heavy matched filter runs later, in bounded chunks, from
-  `acoustic_link_poll()` on the main loop.
+- **TX**: PS1240 driven differentially from GP6/GP7 (`buzzer.c`). Chip dwell is
+  fixed at **250 µs**; the PWM carrier may retune every chip (`buzzer_tx_chips_fh`).
+- **RX**: [`main.c`](main.c) mono-mixes six mics into `acoustic_link_rx_push()`;
+  `acoustic_link_poll()` runs the matched filter in bounded chunks on the main loop.
 
 ---
 
-## 2. Physical layer (PHY)
-
-Direct-sequence spread spectrum (DSSS) with BPSK on a 4 kHz carrier.
+## 2. Physical layer (PHY) — v1.4
 
 | Parameter | Symbol | Value |
 |---|---|---|
-| Carrier | `ALINK_CARRIER_HZ` | 4000 Hz |
 | Sample rate | `ALINK_FS_HZ` | 48000 Hz |
-| Samples per carrier cycle | `ALINK_SAMPLES_CYCLE` | 12 |
-| Carrier cycles per chip | `ALINK_CYCLES_CHIP` | 8 |
-| Samples per chip | `ALINK_SAMPLES_CHIP` | 96 |
-| Chip rate | `ALINK_CHIP_HZ` | 500 chip/s (2 ms/chip) |
-| Preamble length | `ALINK_PREAMBLE_LEN` | 127 chips |
-| Data spreading factor | `ALINK_DATA_SF` | 8 chips/bit |
-| Distinct node codes | `ALINK_MAX_NODES` | 8 |
+| Chip dwell | `ALINK_CHIP_US` | **250 µs** |
+| Samples per chip | `ALINK_SAMPLES_CHIP` | 12 |
+| Preamble carrier | `ALINK_PREAMBLE_HZ` | 4000 Hz (PS1240 resonance) |
+| Preamble length | `ALINK_PREAMBLE_LEN` | **31** chips (CDMA) |
+| Data modulation | — | **non-coherent 2-FSK** on hop set |
+| Hop set size | `ALINK_NHOPS` | 8 |
+| Hop frequencies | `g_hop_hz[]` | 3000, 3400, 3800, 4000, 4200, 4600, 5000, 5400 Hz |
+| Data SF | `ALINK_DATA_SF` | 1 chip / bit |
+| Nodes | `ALINK_MAX_NODES` | 8 |
+| Frame chips | `ALINK_TX_CHIPS` | **279** (= 31 + 248) |
+| **Air-time** | — | **279 × 250 µs = 69.75 ms** |
 
-Each transmitted chip is a phase (0 or 180 deg). A BPSK amplitude `a in {+1,-1}`
-maps to a phase bit `p = (a < 0)`. The despreader recovers a data bit `b` because
+### Why FHSS + 2-FSK (not BPSK-on-hop)
 
-```
-1 - 2*(b XOR c) = (1 - 2*b) * (1 - 2*c)
-```
+Retuning the PWM wrap each chip **resets carrier phase**, so coherent BPSK on
+hopping tones is unreliable. Data bits therefore select one of two hop tones
+(offset by `NHOPS/2` in the table); the receiver compares non-coherent energy.
+The **preamble stays BPSK at fixed 4 kHz** so CDMA acquisition and ToA still work.
 
-so multiplying the received chip by the local code chip `(1 - 2*c)` and summing
-over the spreading factor yields `(1 - 2*b) * SF * channel`.
+### Preamble codes (CDMA)
 
-### Codes (CDMA)
+Length-31 m-sequence (`x^5 + x^2 + 1`) with distinct circular shifts per
+`node_id` (step 3). Acquisition correlates I/Q at 4 kHz against all 8 codes.
 
-Per-node codes are a **Gold-code family** built from two maximal-length degree-7
-LFSRs (a preferred-pair construction):
+### Idle piezo keepalive
 
-- seq A: `x^7 + x^6 + 1`
-- seq B: `x^7 + x^3 + 1`
-- node code: `code_n[k] = A[k] XOR B[(k + n) mod 127]`, mapped to +/-1.
-
-The **preamble** is the sender's full length-127 code (used for acquisition,
-sender identity, and time-of-arrival). The **data spreading code** is the first
-`SF` chips of the same code. Distinct nodes therefore separate at the correlator
-(code-division multiple access), which is what makes simultaneous transmissions
-survivable.
-
-> Note: the exact preferred-pair optimality of these two polynomials is not
-> bench-verified; node separation also leans on the MAC layer (below).
+The free-running buzzer PN burst is rare (~30 s) and short (31 × 250 µs). Real
+neighbour traffic is the acoustic-link beacon schedule.
 
 ---
 
 ## 3. Frame format
 
-A fixed 31-byte plaintext frame keeps RX sizing constant.
+Still a fixed **31-byte** plaintext (API/layout unchanged); FEC expansion removed.
 
 | Offset | Field | Bytes |
 |---|---|---|
-| 0 | version (`ALINK_VERSION` = 1) | 1 |
+| 0 | version (`ALINK_VERSION` = **2**) | 1 |
 | 1 | node_id (sender) | 1 |
 | 2 | type (BEACON/DETECT/CTRL/ACK) | 1 |
 | 3 | seq | 1 |
 | 4 | flags (encrypted / ack-req / synced) | 1 |
 | 5 | key_id (crypto, reserved) | 1 |
 | 6..9 | nonce (crypto, reserved, LE32) | 4 |
-| 10 | len (payload length 0..16) | 1 |
+| 10 | len (0..16) | 1 |
 | 11..26 | payload (padded to 16) | 16 |
 | 27..30 | CRC32 over bytes 0..26 (LE) | 4 |
 
-- **FEC**: each byte is split into two nibbles, each encoded with **Hamming(7,4)**
-  (single-error-correcting). 31 bytes -> 62 nibbles -> 434 coded bits
-  (`ALINK_CODED_BITS`).
-- **Integrity**: CRC32 (IEEE 802.3 polynomial `0xEDB88320`, the same one used by
-  the flash stores).
-- **Crypto-ready**: the `encrypted` flag plus `key_id`/`nonce` are wired to
-  `crypto_seal()` / `crypto_open()` hooks. Today these are an identity no-op; the
-  target is AEAD (encrypt-then-MAC, e.g. ChaCha20-Poly1305). Because the fields
-  already exist on the wire, enabling encryption later needs no frame change.
+- On air: **248 raw bits** (no Hamming) after the 31-chip preamble.
+- Crypto fields remain wired to stub `crypto_seal` / `crypto_open`.
 
-The coded bit stream is spread to chips as: 127 preamble chips followed by
-`434 * 8 = 3472` data chips, i.e. `ALINK_TX_CHIPS = 3599` chips total.
+### BEACON payload (unchanged semantics)
+
+| Off | Content |
+|---|---|
+| 0..3 | `tx_mono` LE32 |
+| 4..7 | Unix epoch LE32 (0 if unsynced) |
+| 8 | `echo_node` (or `0xFF`) |
+| 9..12 | `t_reply` LE32 |
+| 13 | `echo_seq` |
+| 14 | synced byte |
+| 15 | pad |
 
 ---
 
 ## 4. Multiple access & collision resistance
 
-1. **CDMA** — different nodes use different Gold codes; the correlator recovers
-   the strongest aligned code even when transmissions overlap.
-2. **Slotted-ALOHA jitter** — beacons are scheduled every `BEACON_BASE_MS`
-   (1500 ms) plus a random `BEACON_JITTER_MS` (0..500 ms) so periodic senders
-   drift out of lock-step.
-3. **Listen-before-talk** — `schedule_tx()` refuses to start a new frame while
-   the local PHY is busy (`buzzer_tx_busy()`), so a node never stomps its own TX.
-
-When alone, the node still emits the original periodic PN beacon, so v1.3.0 is a
-no-op change in a single-node setup.
+1. **CDMA preamble** — distinct shifts separate overlapping acquisitions.
+2. **Per-node hop base** — data tone pairs are offset by `node_id * 3`.
+3. **Slotted-ALOHA jitter** — beacons every `BEACON_BASE_MS` (2000 ms) +
+   0..800 ms random.
+4. **Listen-before-talk** — no TX while `buzzer_tx_busy()`.
 
 ---
 
 ## 5. Receiver chain
 
-Runs in `acoustic_link_poll()`, draining the SPSC ring filled by
-`acoustic_link_rx_push()`.
-
-1. **Downconvert** — multiply each mono sample by a 12-entry cos/sin NCO at 4 kHz
-   to get baseband I/Q. Because 48000/4000 = 12 is integer and 96 % 12 = 0, every
-   chip starts at the same NCO phase.
-2. **Integrate-and-dump** — accumulate I/Q over 96 samples to form one complex
-   chip value.
-3. **Acquisition** — push the chip into a 127-deep circular history and correlate
-   (complex, non-coherent) against all `ALINK_MAX_NODES` candidate preamble
-   codes. The normalized peak is
-
-   ```
-   rho = |corr|^2 / (127 * window_energy)   in [0, 1]
-   ```
-
-   A frame is detected when `rho > DETECT_RHO` (0.30) and the window energy
-   exceeds `DETECT_EMIN`. The winning code index is the sender; the correlation
-   phase gives the channel reference `(cos phi, sin phi)`; the chip time is the
-   time-of-arrival (ToA).
-4. **Despread** — for each of the 434 data bits, sum `SF` chips multiplied by the
-   sender's data code, derotate by `phi`, and slice the real part to a bit.
-5. **Decode** — Hamming-decode 434 bits -> 31 bytes, check CRC32 and version,
-   then dispatch. Bad CRC increments `rx_bad_crc` and the receiver returns to
-   search.
+1. Buffer 12-sample chip windows from the mono ring.
+2. **SEARCH** — mix at 4 kHz, correlate length-31 history vs all node codes;
+   accept when `rho > 0.28` and energy gate passes. Winning code ⇒ sender id +
+   phase ref + ToA.
+3. **DATA** — for each bit index, compare energy of the two candidate hop tones;
+   slice the larger as the bit.
+4. Pack 248 bits → 31 bytes, verify CRC32 and `version == 2`, dispatch.
 
 ---
 
-## 6. Two-way ranging (mutual distance)
+## 6. Two-way ranging (SS-TWR)
 
-Beacons double as ranging packets. het68 uses **single-sided two-way ranging
-(SS-TWR)** with broadcast beacons ([`node_store.c`](node_store.c)):
+Unchanged algorithm ([`node_store.c`](node_store.c)): broadcast beacons echo
+`{peer, seq, t_reply}`; initiator computes
+\(\mathrm{ToF}=(T_\mathrm{round}-t_\mathrm{reply})/2\),
+\(\mathrm{distance}=\mathrm{ToF}\cdot c\) with \(c\) from `doa_c_sound_m_s()`.
 
-```mermaid
-sequenceDiagram
-  participant A
-  participant B
-  A->>B: beacon seqA @ t1 (A clock)
-  Note over B: receive ToA t2 (B clock)
-  B->>A: beacon @ t3 (B clock), echo {A, seqA, t_reply = t3 - t2}
-  Note over A: receive ToA t4 (A clock)
-  Note over A: Tround = t4 - t1
-  Note over A: ToF = (Tround - t_reply) / 2
-  Note over A: distance = ToF * c
-```
-
-- `A` remembers the transmit time `t1` of each of its recent beacon polls
-  (`node_store_note_tx`, an 8-deep ring keyed by seq). The accurate `t1` is the
-  preamble emission time reported by `buzzer_tx_start_us()`.
-- `B` echoes the most-recently-heard peer in its next beacon: `echo_node`,
-  `echo_seq`, and the turnaround `t_reply = now - last_rx` (`node_store_pending_echo`).
-- When `A` hears a beacon whose `echo_node == A` and `echo_seq` matches an
-  outstanding poll, it computes `ToF` and then `distance = ToF * c`.
-- **c** is the current speed of sound from the DPS310 model (`doa_c_sound_m_s()`),
-  so ranging tracks temperature/pressure/humidity.
-- Sanity gate: `0 <= ToF < 600 ms` (~200 m); otherwise the sample is rejected.
-
-The coarse relative clock offset is also derived:
-`offset(A-B) = t4 - t3 - ToF`, where `t3` is the peer's transmit timestamp carried
-in the payload.
+Chip resolution is now **250 µs ≈ 8.6 cm** at \(c \approx 343\,\mathrm{m/s}\)
+(was ~0.69 m at 2 ms chips).
 
 ---
 
 ## 7. Time synchronization
 
-Two levels:
-
-- **Coarse (epoch) sync.** A synced node advertises `flags.SYNCED` and puts its
-  Unix epoch in the beacon payload. An **unsynced** node adopts it via
-  `het68_time_sync_from(epoch, HET68_TIME_SRC_ACOUSTIC, quality=60)`. This makes
-  `TIME` / `TIME INFO` report source `acoustic`, alongside the existing `uart`
-  and `rid` sources ([`het68_time.h`](het68_time.h)). Detection-log timestamps
-  then work on nodes that never received a UART or OpenDroneID time.
-- **Fine (offset) sync.** The SS-TWR exchange yields the per-peer
-  `clock_offset_us` (see section 6), which quantifies the residual skew between
-  neighbours and can later discipline a local phase-locked estimate.
-
-The acoustic epoch quality (60) is deliberately lower than UART/RID so a direct
-time source always wins.
+- Coarse: synced peer sets `SYNCED` + epoch → unsynced node adopts via
+  `HET68_TIME_SRC_ACOUSTIC` (quality 60).
+- Fine: per-peer `clock_offset_us` from SS-TWR (shown in `LINK`).
 
 ---
 
-## 8. Wi-Fi wake / OTA (control plane -> data plane)
+## 8. Wi-Fi wake / OTA
 
-The acoustic link is a low-rate **always-on control plane**. For bulk data or
-firmware upgrade it can hand off to Wi-Fi:
-
-- A `CTRL` frame with subtype `WIFI_WAKE` carries a rendezvous token.
-- On receipt, CYW43 boards (`pico_w`, `pico2_w`, Pico Plus 2 W) flag a Wi-Fi
-  bring-up (`HET68_WIFI_WAKE=1`); the application layer polls
-  `acoustic_link_wifi_wake_pending()` to drive the STA connect + bulk sync / OTA.
-  On non-wireless `pico2` the handler compiles to a stub that only logs.
-
-> The actual STA connect + OTA transfer is intentionally deferred: it needs
-> SSID/credential provisioning and must coexist with the BTstack/RID `cyw43_arch`
-> instance. The wire format and trigger are in place now.
+`CTRL WIFI_WAKE` still flags `acoustic_link_wifi_wake_pending()`; STA/OTA path
+remains deferred (credentials + BTstack coexistence).
 
 ---
 
-## 9. CLI reference
-
-Over the debug UART (see [`cli.c`](cli.c)):
+## 9. CLI
 
 | Command | Action |
 |---|---|
-| `LINK` | link status + peer/ranging table |
-| `LINK ID <0-7>` | set this node's acoustic id / CDMA code |
+| `LINK` | status (`ver`, `air_ms`, counters) + peer table |
+| `LINK ID <0-7>` | set acoustic id / CDMA shift |
 | `LINK BEACON` | send one beacon now |
-| `LINK WIFI` | broadcast a `WIFI_WAKE` control frame |
+| `LINK WIFI` | broadcast `WIFI_WAKE` |
 
-`STATUS` and the boot dump include the `LINK` block:
-`node`, `tx`, `rx`, `bad_crc`, `peers`, `wifi_wake`, followed by the peer table
-(`id`, `rx`, `q`, `dist_m`, `offset_us`, `synced`).
-
-The fixed node id can also be set at build time: `HET68_NODE_ID=3 ./build.sh`.
+Build-time id: `HET68_NODE_ID=3 ./build.sh`.
 
 ---
 
-## 10. Air-time & data-rate budget
+## 10. Air-time & audibility
 
-- Chip = 2 ms. Preamble = 127 chips = 254 ms. Data = 3472 chips = 6.944 s.
-  **One frame ~ 7.2 s** on air.
-- Net information: 31 bytes/frame over ~7.2 s ~= 34 info bit/s (payload is 16 of
-  those bytes).
-- Beacon cadence is therefore effectively `max(BEACON_BASE_MS, frame air-time)`
-  plus jitter.
+| | v1.3.x | **v1.4.0** |
+|---|---|---|
+| Chips / frame | 3599 | **279** |
+| Chip dwell | 2 ms | **0.25 ms** |
+| Air-time | ~7.2 s | **~70 ms** |
+| Modulation | DSSS-BPSK @ 4 kHz | BPSK preamble + **2-FSK FHSS** |
+| FEC | Hamming(7,4) | CRC32 only |
 
-This is intentionally a slow, robust control/ranging plane. To trade robustness
-for speed, reduce `ALINK_DATA_SF`, shorten the frame, or raise the chip rate
-(`ALINK_CYCLES_CHIP`). Larger payloads and OTA belong on the Wi-Fi plane.
-
----
-
-## 11. Audibility
-
-The link stays on the ~4 kHz PS1240 resonance (chosen for range), which is in the
-most sensitive human hearing band, so it is **not truly inaudible**. Perceptibility
-is minimized by spread-spectrum coding (energy spread thin, RX works below 0 dB
-SNR via processing gain), low duty cycle, and randomized timing, so bursts sound
-like faint clicks/hiss rather than a tone.
+Duty cycle at a 2 s beacon period ≈ **3.5%** on-air. Hopping spreads energy
+across ~3–5.4 kHz so bursts sound like short ticks/chirps rather than a long
+whistle. Still audible (PS1240 is in-band); not claimed silent.
 
 ---
 
-## 12. Limitations & future work
+## 11. Limitations & future work
 
-- **Not hardware-validated**: acquisition thresholds, ToA precision, and the
-  Gold preferred-pair choice are best-effort and need bench tuning.
-- **ToA is chip-resolution** today (2 ms ~ 0.69 m). Sub-chip interpolation on the
-  correlation peak would sharpen ranging.
-- **SS-TWR** assumes reciprocity; **double-sided TWR** would cancel clock skew.
-- **Crypto** is a no-op stub; wiring real AEAD into `crypto_seal`/`crypto_open`
-  enables the `encrypted` flag with no wire change.
-- **Wi-Fi** wake sets a flag only; the STA connect + OTA path is future work.
+- Not fully bench-validated (thresholds, outdoor range, hop SPL roll-off).
+- No Hamming — rely on CRC + frequent short beacons.
+- 2-FSK hop pairs assume usable SPL off exact resonance; extreme hops are weaker.
+- Sub-chip ToA interpolation would sharpen ranging further.
+- Crypto / Wi-Fi OTA still stubs.
 
 ---
 
-## 13. Source map
+## 12. Source map
 
-- [`acoustic_link.h`](acoustic_link.h) / [`acoustic_link.c`](acoustic_link.c) —
-  PHY, framing, FEC/CRC, crypto hooks, TX scheduler, RX matched filter, dispatch.
-- [`node_store.h`](node_store.h) / [`node_store.c`](node_store.c) — peer table,
-  SS-TWR ranging, clock offset.
-- [`buzzer.h`](buzzer.h) / [`buzzer.c`](buzzer.c) — piezo PHY + chip-stream TX.
-- [`het68_time.h`](het68_time.h) / [`het68_time.c`](het68_time.c) — clock with the
-  `acoustic` source.
-- [`main.c`](main.c) — mono RX tap + `acoustic_link_poll()` in the main loop.
-- [`cli.c`](cli.c) — `LINK` commands + `STATUS` integration.
+- [`acoustic_link.h`](acoustic_link.h) / [`acoustic_link.c`](acoustic_link.c)
+- [`node_store.h`](node_store.h) / [`node_store.c`](node_store.c)
+- [`buzzer.h`](buzzer.h) / [`buzzer.c`](buzzer.c) — FHSS chip stream
+- [`het68_time.*`](het68_time.h) — `acoustic` time source
+- [`main.c`](main.c) / [`cli.c`](cli.c)

--- a/main.c
+++ b/main.c
@@ -895,7 +895,7 @@ int main(void)
         node_id = (uint8_t)(HET68_NODE_ID);
 #endif
         acoustic_link_init(node_id);
-        dbg_puts("LINK: acoustic node link (GP6/GP7 4kHz DSSS) node=");
+        dbg_puts("LINK: acoustic node link (GP6/GP7 FHSS-BPSK <100ms) node=");
         dbg_putu32(node_id);
         dbg_putc('\n');
     }

--- a/wiki.cs.md
+++ b/wiki.cs.md
@@ -3,7 +3,7 @@
 Jazyk: **Čeština** · [English](wiki.md)
 
 Tato wiki vysvětluje **současné** řešení het68 na větvi `main`
-(akustický node link **v1.3.x** a související subsystémy). Rozšiřuje praktické
+(akustický node link **v1.4.x** a související subsystémy). Rozšiřuje praktické
 otázky kolem UART logů a formátu chirp zpráv a zasazuje je do zbytku stacku.
 
 Úplná protokolová reference (PHY, ranging, MAC, air-time):
@@ -48,7 +48,7 @@ flowchart TB
     cli["UART CLI"]
   end
   subgraph air [Akustický node link]
-    piezo["PS1240 GP6/GP7 DSSS-BPSK"]
+    piezo["PS1240 GP6/GP7 FHSS ~70ms"]
     peers["node_store peers / dist / offset"]
   end
   mics --> usb
@@ -65,8 +65,8 @@ flowchart TB
   time --> cli
 ```
 
-- **TX chirp:** APP rámec → CRC32 + Hamming(7,4) → Gold CDMA čipy →
-  `buzzer_tx_chips()` na GP6/GP7.
+- **TX chirp:** APP rámec → CRC32 → 31čipová BPSK preambule @ 4 kHz +
+  2-FSK FHSS data → `buzzer_tx_chips_fh()` na GP6/GP7 (~70 ms air-time).
 - **RX chirp:** šest miků smícháno do mono v `build_usb_frame_from_i2s()` →
   `acoustic_link_rx_push()` (levný ring) → matched filter v
   `acoustic_link_poll()` (ohraničeně, main loop).
@@ -90,7 +90,7 @@ Při **automatickém příjmu** se na UART vypíše jen několik typů rámců. 
 
 | Událost | Typický UART řádek | Poznámka |
 |---|---|---|
-| Boot / init | `LINK: acoustic node link … node=` | Jednou při startu |
+| Boot / init | `LINK: acoustic node link (… FHSS-BPSK <100ms) node=` | Jednou při startu |
 | Rámec `DETECT` | `LINK DETECT from=<id> cls=<n>` | Peer id + bajt třídy |
 | `CTRL` `WIFI_WAKE` | `LINK: WIFI_WAKE token=…` nebo „no Wi-Fi…“ | Nastaví i wake-pending flag |
 | `CTRL` `OTA_REQ` | `LINK: OTA_REQ received` | Placeholder; OTA přenos ještě není |
@@ -104,7 +104,7 @@ se **nepíšou** při každém dekódu.
 `acoustic_link_status_uart()` a pak `node_store_list_uart()`:
 
 ```
-LINK node=<id> tx=<n> rx=<n> bad_crc=<n> peers=<n> wifi_wake=<0|1>
+LINK node=<id> ver=2 air_ms=69 tx=<n> rx=<n> bad_crc=<n> peers=<n> wifi_wake=<0|1>
 === node peers ===
 NODE id=<id> rx=<n> q=<0.xx> dist_m=<m>|dist=? offset_us=<…> synced=<0|1>
 …
@@ -112,6 +112,7 @@ NODE id=<id> rx=<n> q=<0.xx> dist_m=<m>|dist=? offset_us=<…> synced=<0|1>
 
 | Pole | Význam |
 |---|---|
+| `ver` / `air_ms` | Verze na drátě (2) a nominální air-time chirpu |
 | `tx` / `rx` / `bad_crc` | Lokální počítadla linku |
 | `peers` | Obsazené sloty v `node_store` (max 8) |
 | `q` | Poslední kvalita matched filtru \(0..1\) |
@@ -123,7 +124,7 @@ CLI: `LINK`, `LINK ID <0-7>`, `LINK BEACON`, `LINK WIFI` — viz [`cli.c`](cli.c
 
 ### Proč je BEACON tichý
 
-Maják trvá ~7,2 s na vzduchu a opakuje se často. Logovat každý dekód by
+Maják trvá jen ~70 ms na vzduchu, ale opakuje se často. Logovat každý dekód by
 zaplavilo UART a překrylo DET/RID/CMP provoz. Návrh: **tiché uložení +
 explicitní dump**.
 
@@ -133,12 +134,11 @@ explicitní dump**.
 
 ### Pevná velikost na vzduchu (vždy)
 
-Každý rámec je **pevných 31 bajtů** plaintextu před FEC a pak vždy stejná
-zakódovaná délka. Velikost RX zůstává konstantní.
+Každý rámec je **pevných 31 bajtů** plaintextu. Na vzduchu (v1.4 / wire v2):
 
 | Offset | Pole | Bajtů |
 |---|---|---|
-| 0 | `version` (`ALINK_VERSION` = 1) | 1 |
+| 0 | `version` (`ALINK_VERSION` = **2**) | 1 |
 | 1 | `node_id` (odesílatel, 0..7) | 1 |
 | 2 | `type` | 1 |
 | 3 | `seq` | 1 |
@@ -149,8 +149,8 @@ zakódovaná délka. Velikost RX zůstává konstantní.
 | 11..26 | `payload` (vždy doplněno na 16) | 16 |
 | 27..30 | CRC32 LE přes bajty 0..26 | 4 |
 
-Pak: Hamming(7,4) → **434** kódovaných bitů → DSSS SF=8 → **3472** datových
-čipů + **127** preambulí = **3599** čipů ≈ **7,2 s** při 500 čip/s.
+Pak: **248 raw bitů** (bez Hammingu) jako 2-FSK hopy + **31** BPSK preambulí
+@ 4 kHz = **279** čipů × **250 µs** ≈ **70 ms**.
 
 ### Co se skutečně mění
 
@@ -159,11 +159,11 @@ Variabilita je **sémantická**, ne délková:
 1. **`type`** — `BEACON=0`, `DETECT=1`, `CTRL=2`, `ACK=3`
 2. **`flags`** — `ENCRYPTED` (0x01, stub), `ACK_REQ` (0x02), `SYNCED` (0x04)
 3. **`seq`**, **`node_id`**, počítadla / časová razítka v payloadu
-4. **CDMA kód** — podle `node_id` odesílatele (Gold rodina); není pole v payloadu
-5. **`len`** — deklarováno 0..16, TX ale stejně paduje 16bajtový slot
+4. **CDMA posun preambule** + **základ hop páru** — z `node_id`
+5. **Hop tón na bit** — která ze dvou FSK frekvencí nese bit
+6. **`len`** — deklarováno 0..16; TX stejně paduje 16bajtový slot
 
-Co se **nemění**: počet bajtů rámce, kódovaných bitů, čipů, nosná (4 kHz),
-čipová rychlost, spreading factor.
+Co se **nemění**: počet bajtů rámce, počet čipů, dwell čipu, air-time.
 
 ### Layouty payloadu (uvnitř pevných 16 B)
 
@@ -220,17 +220,15 @@ Akustická quality je záměrně nižší než UART/RID, aby přímý zdroj vyhr
 
 ## 6. Vícenásobný přístup, rychlost a slyšitelnost
 
-- **CDMA:** až 8 Gold kódů (`ALINK_MAX_NODES`); korelátor bere nejsilnější
-  shodu preambule (`rho > 0.30` + energetický práh).
-- **Slotted-ALOHA jitter:** základ majáku ~1500 ms + 0..500 ms náhodně; plus
-  listen-before-talk (`buzzer_tx_busy()`).
-- **Propustnost:** ~31 info bajtů / ~7,2 s ≈ **34 bit/s** — jen řídicí/ranging
-  rovina. Bulk / OTA → `WIFI_WAKE` a pak Wi-Fi (STA cesta je zatím odložená).
-- **Slyšitelnost:** 4 kHz je v citlivém pásmu sluchu; spread spectrum + nízký
-  duty cyklus dávají spíš „slabé kliky/šum“, ne ticho.
-
-Kompromisy pro rychlejší link (budoucnost): nižší `ALINK_DATA_SF`, kratší rámec
-nebo vyšší čipová rychlost (`ALINK_CYCLES_CHIP`).
+- **CDMA preambule:** 8 posunů m-sekvence délky 31; korelátor bere nejsilnější
+  shodu (`rho > 0.28` + energetický práh).
+- **FHSS data:** 8tónová hop množina; bit = porovnání energie páru tónů.
+- **Slotted-ALOHA jitter:** základ majáku ~2000 ms + 0..800 ms náhodně; LBT přes
+  `buzzer_tx_busy()`.
+- **Propustnost:** ~31 info bajtů / ~70 ms burst, duty ~3,5 % při periodě 2 s —
+  řídicí/ranging rovina. Bulk / OTA → `WIFI_WAKE` a Wi-Fi (odloženo).
+- **Slyšitelnost:** krátké hopnuté tiky místo vícenásobného 4kHz pískotu; pořád
+  ne ticho.
 
 ---
 
@@ -279,12 +277,14 @@ Protokol do hloubky: [`chirp.cs.md`](chirp.cs.md). Zdroje: `acoustic_link.*`,
 
 ## 9. Známá omezení (upřímný snapshot)
 
-- Není plně ověřeno na hardwaru (práh, Gold pár, přesnost ToA).
-- ToA je dnes v **rozlišení čipu** (~2 ms ≈ 0,69 m při \(c \approx 343\,\mathrm{m/s}\));
-  sub-chip interpolace peaku by ranging zpřesnila.
+- Není plně ověřeno na hardwaru (práh, hop SPL, přesnost ToA).
+- ToA je v **rozlišení čipu** (~250 µs ≈ 8,6 cm při \(c \approx 343\,\mathrm{m/s}\));
+  sub-chip interpolace peaku by ranging ještě zpřesnila.
+- Bez Hamming FEC — CRC + časté krátké majáky.
 - SS-TWR ≠ double-sided TWR (rušení skew není kompletní).
 - Crypto a Wi-Fi OTA jsou hooky/stuby, ne end-to-end funkce.
 - BEACON RX záměrně nejde na UART — peery prohlížej přes `LINK`.
+- v1.4 (`version=2`) **není** interoperabilní s v1.3 DSSS rámci.
 
 ---
 

--- a/wiki.md
+++ b/wiki.md
@@ -3,7 +3,7 @@
 Language: **English** · [Čeština](wiki.cs.md)
 
 This wiki explains the **current** het68 solution as shipped on `main`
-(acoustic node link **v1.3.x** and related subsystems). It expands the practical
+(acoustic node link **v1.4.x** and related subsystems). It expands the practical
 questions that come up when reading UART logs and the chirp wire format, and
 ties them into the rest of the stack.
 
@@ -49,7 +49,7 @@ flowchart TB
     cli["UART CLI"]
   end
   subgraph air [Acoustic node link]
-    piezo["PS1240 GP6/GP7 DSSS-BPSK"]
+    piezo["PS1240 GP6/GP7 FHSS ~70ms"]
     peers["node_store peers / dist / offset"]
   end
   mics --> usb
@@ -66,8 +66,8 @@ flowchart TB
   time --> cli
 ```
 
-- **TX path for chirp:** APP frame → CRC32 + Hamming(7,4) → Gold CDMA chips →
-  `buzzer_tx_chips()` on GP6/GP7.
+- **TX path for chirp:** APP frame → CRC32 → 31-chip BPSK preamble @ 4 kHz +
+  2-FSK FHSS data chips → `buzzer_tx_chips_fh()` on GP6/GP7 (~70 ms air-time).
 - **RX path for chirp:** six mics mixed to mono inside `build_usb_frame_from_i2s()`
   → `acoustic_link_rx_push()` (cheap ring) → matched filter in
   `acoustic_link_poll()` (bounded, main loop).
@@ -91,7 +91,7 @@ On **automatic receive**, only a few frame types print a line. Successful
 
 | Event | Typical UART line | Notes |
 |---|---|---|
-| Boot / init | `LINK: acoustic node link … node=` | Once at bring-up |
+| Boot / init | `LINK: acoustic node link (… FHSS-BPSK <100ms) node=` | Once at bring-up |
 | `DETECT` frame | `LINK DETECT from=<id> cls=<n>` | Logs peer id + class byte |
 | `CTRL` `WIFI_WAKE` | `LINK: WIFI_WAKE token=…` or “no Wi-Fi on this board” | Also sets wake-pending flag |
 | `CTRL` `OTA_REQ` | `LINK: OTA_REQ received` | Placeholder; no OTA transfer yet |
@@ -105,7 +105,7 @@ tables are **not** spammed on every decode.
 `acoustic_link_status_uart()` then `node_store_list_uart()`:
 
 ```
-LINK node=<id> tx=<n> rx=<n> bad_crc=<n> peers=<n> wifi_wake=<0|1>
+LINK node=<id> ver=2 air_ms=69 tx=<n> rx=<n> bad_crc=<n> peers=<n> wifi_wake=<0|1>
 === node peers ===
 NODE id=<id> rx=<n> q=<0.xx> dist_m=<m>|dist=? offset_us=<…> synced=<0|1>
 …
@@ -113,6 +113,7 @@ NODE id=<id> rx=<n> q=<0.xx> dist_m=<m>|dist=? offset_us=<…> synced=<0|1>
 
 | Field | Meaning |
 |---|---|
+| `ver` / `air_ms` | Wire version (2) and nominal chirp air-time |
 | `tx` / `rx` / `bad_crc` | Local link counters |
 | `peers` | Occupied slots in `node_store` (max 8) |
 | `q` | Last matched-filter quality \(0..1\) |
@@ -124,9 +125,9 @@ CLI: `LINK`, `LINK ID <0-7>`, `LINK BEACON`, `LINK WIFI` — see [`cli.c`](cli.c
 
 ### Why BEACON is quiet
 
-A beacon is ~7.2 s on air and repeats often. Logging every decode would flood
-UART and hide DET/RID/CMP traffic. The design is: **silent store + explicit
-dump**.
+A beacon is only ~70 ms on air but still repeats often. Logging every decode
+would flood UART and hide DET/RID/CMP traffic. The design is: **silent store +
+explicit dump**.
 
 ---
 
@@ -134,12 +135,11 @@ dump**.
 
 ### Fixed on-air size (always)
 
-Every frame is a **fixed 31-byte plaintext** before FEC, then always the same
-coded length on the air. RX sizing stays constant.
+Every frame is a **fixed 31-byte plaintext**. On air (v1.4 / wire v2):
 
 | Offset | Field | Bytes |
 |---|---|---|
-| 0 | `version` (`ALINK_VERSION` = 1) | 1 |
+| 0 | `version` (`ALINK_VERSION` = **2**) | 1 |
 | 1 | `node_id` (sender, 0..7) | 1 |
 | 2 | `type` | 1 |
 | 3 | `seq` | 1 |
@@ -150,8 +150,8 @@ coded length on the air. RX sizing stays constant.
 | 11..26 | `payload` (always padded to 16) | 16 |
 | 27..30 | CRC32 LE over bytes 0..26 | 4 |
 
-Then: Hamming(7,4) → **434** coded bits → DSSS SF=8 → **3472** data chips +
-**127** preamble chips = **3599** chips ≈ **7.2 s** at 500 chip/s.
+Then: **248 raw bits** (no Hamming) as 2-FSK hops + **31** BPSK preamble chips
+@ 4 kHz = **279** chips × **250 µs** ≈ **70 ms**.
 
 ### What actually varies
 
@@ -160,11 +160,11 @@ Variability is **semantic**, not length:
 1. **`type`** — `BEACON=0`, `DETECT=1`, `CTRL=2`, `ACK=3`
 2. **`flags`** — `ENCRYPTED` (0x01, stub), `ACK_REQ` (0x02), `SYNCED` (0x04)
 3. **`seq`**, **`node_id`**, counters / timestamps inside payload
-4. **CDMA code** — chosen by sender `node_id` (Gold family); not a payload field
-5. **`len`** — declared 0..16, but TX still pads the 16-byte payload slot
+4. **CDMA preamble shift** + **hop-pair base** — from sender `node_id`
+5. **Per-bit hop tone** — which of two FSK frequencies carries the bit
+6. **`len`** — declared 0..16; TX still pads the 16-byte payload slot
 
-What does **not** vary today: frame byte count, coded bit count, chip count,
-carrier (4 kHz), chip rate, spreading factor.
+What does **not** vary: frame byte count, chip count, chip dwell, air-time.
 
 ### Payload layouts (inside the fixed 16 B)
 
@@ -220,17 +220,15 @@ Acoustic quality is intentionally below UART/RID so a direct source wins.
 
 ## 6. Multiple access, rate, and audibility
 
-- **CDMA:** up to 8 Gold codes (`ALINK_MAX_NODES`); correlator picks strongest
-  preamble match (`rho > 0.30` + energy gate).
-- **Slotted-ALOHA jitter:** beacon base ~1500 ms + 0..500 ms random; plus
-  listen-before-talk (`buzzer_tx_busy()`).
-- **Throughput:** ~31 info bytes / ~7.2 s ≈ **34 bit/s** — control/ranging plane
-  only. Bulk / OTA → `WIFI_WAKE` then Wi-Fi (STA path still deferred).
-- **Audibility:** 4 kHz is in the sensitive hearing band; spread spectrum + low
-  duty make it “faint clicks/hiss”, not silent.
-
-Trade-offs for a faster link (future): lower `ALINK_DATA_SF`, shorter frame, or
-higher chip rate (`ALINK_CYCLES_CHIP`).
+- **CDMA preamble:** 8 shifts of a length-31 m-sequence; correlator picks the
+  strongest match (`rho > 0.28` + energy gate).
+- **FHSS data:** 8-tone hop set; bit = energy compare of a tone pair.
+- **Slotted-ALOHA jitter:** beacon base ~2000 ms + 0..800 ms random; LBT via
+  `buzzer_tx_busy()`.
+- **Throughput:** ~31 info bytes / ~70 ms burst, duty ~3.5% at 2 s period —
+  control/ranging plane. Bulk / OTA → `WIFI_WAKE` then Wi-Fi (deferred).
+- **Audibility:** short hopped ticks instead of a multi-second 4 kHz whistle;
+  still not silent.
 
 ---
 
@@ -279,11 +277,13 @@ Deep protocol: [`chirp.md`](chirp.md). Sources: `acoustic_link.*`, `node_store.*
 ## 9. Known limits (honest snapshot)
 
 - Not fully hardware-validated (thresholds, Gold pair, ToA accuracy).
-- ToA is **chip-resolution** today (~2 ms ≈ 0.69 m at \(c \approx 343\,\mathrm{m/s}\));
-  sub-chip peak interpolation would sharpen ranging.
+- ToA is **chip-resolution** (~250 µs ≈ 8.6 cm at \(c \approx 343\,\mathrm{m/s}\));
+  sub-chip peak interpolation would sharpen ranging further.
+- No Hamming FEC — CRC + frequent short beacons.
 - SS-TWR ≠ double-sided TWR (skew cancellation incomplete).
 - Crypto and Wi-Fi OTA are hooks/stubs, not end-to-end features yet.
 - BEACON RX stays off the UART by design — use `LINK` to inspect peers.
+- v1.4 (`version=2`) is **not** interoperable with v1.3 DSSS frames.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

v1.3’s acoustic link spent **~7.2 s** on air per frame (slow DSSS-BPSK whistle at 4 kHz) — unusable and harsh on the ear. **v1.4.0** keeps the same **PS1240 on GP6/GP7** but redesigns the PHY so one chirp is **~70 ms** (&lt; 100 ms budget).

### PHY changes
- Chip dwell **250 µs** (was 2 ms)
- **31-chip** BPSK preamble @ 4 kHz (CDMA via m-sequence shifts)
- Data: **non-coherent 2-FSK** on an **8-tone hop set** (3.0–5.4 kHz) — PWM retune resets phase, so BPSK-on-hop is avoided
- Dropped Hamming expansion; CRC32 + wire **`ALINK_VERSION = 2`** (not interoperable with 1.3.x)
- **279 chips × 250 µs = 69.75 ms** air-time
- Buzzer: `buzzer_tx_chips_fh()`, rare idle keepalive (~30 s)

### Also
- Version string `1.4.0`; `LINK` status shows `ver=` / `air_ms=`
- Docs: `chirp.md` / `chirp.cs.md`, `wiki.md` / `wiki.cs.md`, `README.md`
- Local `./build.sh` (pico2) succeeds

### Test plan
- [ ] Flash two nodes with unique `LINK ID`, `LINK BEACON`, confirm short audible ticks (~70 ms) not multi-second tones
- [ ] `LINK` shows `ver=2 air_ms=69`, peers / ranging after mutual beacons
- [ ] Confirm v1.3 peer cannot decode v1.4 frames (expected)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb782ee5-f81c-4e3f-b61e-280c3eb24321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

